### PR TITLE
module: fix module name to oteps instead of rfcs

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/open-telemetry/rfcs
+module github.com/open-telemetry/oteps
 
 go 1.12
 


### PR DESCRIPTION
Fix module name to `oteps` instead of `rfcs`.

Currently, Go file is only of `internal/tools.go`. Also, I know `https://github.com/open-telemetry/rfcs?go-get=1` will redirect `https://github.com/open-telemetry/oteps?go-get=1`.
But I think better to fix the module name correctly.