### PR TITLE
README: Fix broken Circle CI SVG

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ Have suggestions? Concerns? Questions? **Please** raise an issue or raise the ma
 
 Our RFC process borrows from the [Rust RFC](https://github.com/rust-lang/rfcs) and [Kubernetes Enhancement Proposal](https://github.com/kubernetes/enhancements) processes, the former also being [very influential](https://github.com/kubernetes/enhancements/blob/master/keps/0001-kubernetes-enhancement-proposal-process.md#prior-art) on the latter; as well as the [OpenTracing RFC](https://github.com/opentracing/specification/tree/master/rfc) process. Massive kudos and thanks to the respective authors and communities for providing excellent prior art 💖
 
-[circleci-image]: https://circleci.com/gh/open-telemetry/rfcs.svg?style=svg 
-[circleci-url]: https://circleci.com/gh/open-telemetry/rfcs
+[circleci-image]: https://circleci.com/gh/open-telemetry/oteps.svg?style=svg 
+[circleci-url]: https://circleci.com/gh/open-telemetry/oteps
 [gitter-image]: https://badges.gitter.im/open-telemetry/opentelemetry-specification.svg 
 [gitter-url]: https://gitter.im/open-telemetry/opentelemetry-specification?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge


### PR DESCRIPTION
The README badge is currently broken because it points to the old repo name (open-telemetry/rfcs). This PR points it to the current name (open-telemetry/oteps).