### PR TITLE
Standard system metrics and semantic conventions

### DIFF
--- a/text/0000-standard-system-metrics.md
+++ b/text/0000-standard-system-metrics.md
@@ -4,17 +4,9 @@ This OTEP proposes a set of standard names and semantic conventions for common s
 
 This OTEP is largely based on the existing implementation in the OpenTelemetry Collector's [Host Metrics Receiver](https://github.com/open-telemetry/opentelemetry-collector/tree/1ad767e62f3dff6f62f32c7360b6fefe0fbf32ff/receiver/hostmetricsreceiver). The proposed names aim to make system/runtime metrics easily discoverable and unambiguous. See [OTEP #108](https://github.com/open-telemetry/oteps/pull/108/files) for additional motivation.
 
-## Explanation
-The following semantic conventions aim to keep naming consistent across different metrics. Not all possible metrics are covered by these conventions, but they provide guidelines for most of the cases in this proposal:
-- **usage** - an instrument that measures an amount used out of a known total amount should be called `entity.usage`. For example, `system.filesystem.usage` for the amount of disk spaced used. A measure of the amount of an unlimited resource consumed is differentiated from **usage**. This may be time, data, etc. *(I'm open to adjusting this to unit names or something else).*
-- **utilization** - an instrument that measures *percent* usage should be called `entity.utilization`. For example, `system.memory.utilization` for the percentage of memory in use. *(I'm open to a shorter name, but wanted to distinguish between usage as an amount and a percentage).*
-- **time** - an instrument that measures passage of time should be called `entity.time`. For example, `system.cpu.time` with varying values of label `state` for idle, user, etc.
-- **io** - an instrument that measures bidirectional data flow should be called `entity.io` and have labels for direction. For example, `system.net.io`.
-- Other metrics that do not fit the above descriptions may be named more freely. Units do not *need* to be specified in the names, but can be added if there is ambiguity. For example, `system.swap.page_faults` and `system.net.packets`. 
-
 ## Trade-offs and mitigations
 
-When choosing a metric name, there is a trade off between discoverability and ambiguity. For example, a metric called `system.cpu.load_average` is very discoverable, but the meaning of this metric is ambiguous. [Load average](https://en.wikipedia.org/wiki/Load_(computing)) is well defined on UNIX, but is not defined on Windows. Metric names must strike a balance between easy discovery and a concise summary of what the metric represents. 
+When choosing a metric name, there is a trade off between discoverability and ambiguity. For example, a metric called `system.cpu.load_average` is very discoverable, but the meaning of this metric is ambiguous. [Load average](https://en.wikipedia.org/wiki/Load_(computing)) is well defined on UNIX, but is not a standard metric on Windows. While discoverability is important, metric names must be unambiguous. 
 
 ## Prior art
 There is an existing metric naming proposal [here](https://docs.google.com/spreadsheets/d/1WlStcUe2eQoN1y_UF7TOd6Sw7aV_U0lFcLk5kBNxPsY/edit#gid=0). In addition, there are already a few implementations of system and/or runtime metric collection in OpenTelemetry:
@@ -46,107 +38,100 @@ There is an existing metric naming proposal [here](https://docs.google.com/sprea
 - Should the individual runtimes have their specific naming conventions in the spec?
 - Establishing consistent base units for instruments of the same family e.g. seconds vs. milliseconds.
 
+## Semantic Conventions
+The following semantic conventions aim to keep naming consistent across different metrics. Not all possible metrics are covered by these conventions, but they provide guidelines for most of the cases in this proposal:
+- **usage** - an instrument that measures an amount used out of a known total amount should be called `entity.usage`. For example, `system.filesystem.usage` for the amount of disk spaced used. A measure of the amount of an unlimited resource consumed is differentiated from **usage**. This may be time, data, etc. *(I'm open to adjusting this to unit names or something else).*
+- **utilization** - an instrument that measures *percent* usage should be called `entity.utilization`. For example, `system.memory.utilization` for the percentage of memory in use. *(I'm open to a shorter name, but wanted to distinguish between usage as an amount and a percentage).*
+- **time** - an instrument that measures passage of time should be called `entity.time`. For example, `system.cpu.time` with varying values of label `state` for idle, user, etc.
+- **io** - an instrument that measures bidirectional data flow should be called `entity.io` and have labels for direction. For example, `system.net.io`.
+- Other metrics that do not fit the above descriptions may be named more freely. Units do not *need* to be specified in the names, but can be added if there is ambiguity. For example, `system.swap.page_faults` and `system.net.packets`. 
+
+
 ## Internal details
 The following standard metric names should be used in libraries instrumenting system/runtime metrics.
 
 ### Standard System Metrics - `system.`
+---
 
 #### `system.cpu.`
 
 **Description:** System level processor metrics.
-
-|Name                  |Units  |Instrument       |Label Key |Label Values|Linux/Windows Support|
-|----------------------|-------|-----------------|----------|------------|---------------------|
-|system.cpu.time       |seconds|SumObserver      |state     |idle        |Both                 |
-|                      |       |                 |          |user        |Both                 |
-|                      |       |                 |          |system      |Both                 |
-|                      |       |                 |          |interrupt   |Both                 |
-|                      |       |                 |          |nice        |Linux                |
-|                      |       |                 |          |softirq     |Linux                |
-|                      |       |                 |          |steal       |Linux                |
-|                      |       |                 |          |wait        |Linux                |
-|system.cpu.utilization|%      |UpDownSumObserver|(as above)|(as above)  |(as above)           |
+|Name                  |Units  |Instrument       |Label Key|Label Values                       |
+|----------------------|-------|-----------------|---------|-----------------------------------|
+|system.cpu.time       |seconds|SumObserver      |state    |idle, user, system, interrupt, etc.|
+|                      |       |                 |cpu      |1 - #cores                         |
+|system.cpu.utilization|%      |UpDownSumObserver|state    |idle, user, system, interrupt, etc.|
+|                      |       |                 |cpu      |1 - #cores                         |
 
 #### `system.memory.`
 
 **Description:** System level memory metrics.
-
-|Name                     |Units|Instrument       |Label Key |Label Values       |Linux/Windows Support|
-|-------------------------|-----|-----------------|----------|-------------------|---------------------|
-|system.memory.usage      |bytes|UpDownSumObserver|state     |used               |Both                 |
-|                         |     |                 |          |free               |Both                 |
-|                         |     |                 |          |buffered           |Linux                |
-|                         |     |                 |          |cached             |Linux                |
-|                         |     |                 |          |slab\_reclaimable  |Linux                |
-|                         |     |                 |          |slab\_unreclaimable|Linux                |
-|system.memory.utilization|%    |UpDownSumObserver|(as above)|(as above)         |(as above)           |
+|Name                     |Units|Instrument       |Label Key|Label Values            |
+|-------------------------|-----|-----------------|---------|------------------------|
+|system.memory.usage      |bytes|UpDownSumObserver|state    |used, free, cached, etc.|
+|system.memory.utilization|%    |UpDownSumObserver|state    |used, free, cached, etc.|
 
 #### `system.swap.`
 
 **Description:** System level swap/paging metrics.
-
-|Name                    |Units|Instrument       |Label Key |Label Values|Linux/Windows Support|
-|------------------------|-----|-----------------|----------|------------|---------------------|
-|system.swap.usage       |pages|UpDownSumObserver|state     |used        |Both                 |
-|                        |     |                 |          |free        |Both                 |
-|system.swap.utilization |%    |UpDownSumObserver|(as above)|(as above)  |(as above)           |
-|system.swap.page\_faults|1    |SumObserver      |type      |major       |Linux                |
-|                        |     |                 |          |minor       |Linux                |
-|system.swap.paging\_ops |1    |SumObserver      |type      |major       |Both                 |
-|                        |     |                 |          |minor       |Linux                |
-|                        |     |                 |direction |in          |Both                 |
-|                        |     |                 |          |out         |Both                 |
-
+|Name                    |Units|Instrument       |Label Key|Label Values|
+|------------------------|-----|-----------------|---------|------------|
+|system.swap.usage       |pages|UpDownSumObserver|state    |used, free  |
+|system.swap.utilization |%    |UpDownSumObserver|state    |used, free  |
+|system.swap.page\_faults|1    |SumObserver      |type     |major, minor|
+|system.swap.paging\_ops |1    |SumObserver      |type     |major, minor|
+|                        |     |                 |direction|in, out     |
 
 #### `system.disk.`
 
 **Description:** System level disk performance metrics.
-
-|Name                        |Units|Instrument |Label Key|Label Values|Linux/Windows Support|
-|----------------------------|-----|-----------|---------|------------|---------------------|
-|system.disk.io<!--notlink-->|bytes|SumObserver|direction|read        |Both                 |
-|                            |     |           |         |write       |Both                 |
-|system.disk.ops             |1    |SumObserver|direction|read        |Both                 |
-|                            |     |           |         |write       |Both                 |
-|system.disk.time            |s    |SumObserver|direction|read        |Both                 |
-|                            |     |           |         |write       |Both                 |
-|system.disk.merged          |1    |SumObserver|direction|read        |Linux                |
-|                            |     |           |         |write       |Linux                |
+|Name                        |Units|Instrument |Label Key|Label Values|
+|----------------------------|-----|-----------|---------|------------|
+|system.disk.io<!--notlink-->|bytes|SumObserver|device   |(identifier)|
+|                            |     |           |direction|read, write |
+|system.disk.ops             |1    |SumObserver|device   |(identifier)|
+|                            |     |           |direction|read, write |
+|system.disk.time            |s    |SumObserver|device   |(identifier)|
+|                            |     |           |direction|read, write |
+|system.disk.merged          |1    |SumObserver|device   |(identifier)|
+|                            |     |           |direction|read, write |
 
 #### `system.filesystem.`
 
 **Description:** System level filesystem metrics. *I think usage/utilization should be consolidated into `system.disk` and the inodes metrics moved to a linux specific namespace.*
-
-|Name                                |Units|Instrument       |Label Key |Label Values|Linux/Windows Support|
-|------------------------------------|-----|-----------------|----------|------------|---------------------|
-|system.filesystem.usage             |bytes|UpDownSumObserver|state     |used        |Both                 |
-|                                    |     |                 |          |free        |Both                 |
-|                                    |     |                 |          |reserved    |Linux                |
-|system.filesystem.utilization       |%    |UpDownSumObserver|(as above)|(as above)  |(as above)           |
-|system.filesystem.inodes.used       |1    |UpDownSumObserver|state     |used        |Linux                |
-|                                    |     |                 |          |free        |Linux                |
-|system.filesystem.inodes.utilization|%    |UpDownSumObserver|(as above)|(as above)  |(as above)           |
+|Name                         |Units|Instrument       |Label Key|Label Values        |
+|-----------------------------|-----|-----------------|---------|--------------------|
+|system.filesystem.usage      |bytes|UpDownSumObserver|device   |(identifier)        |
+|                             |     |                 |state    |used, free, reserved|
+|system.filesystem.utilization|%    |UpDownSumObserver|state    |used, free, reserved|
+|                             |     |                 |device   |(identifier)        |
 
 #### `system.net.`
 
 **Description:** System level network metrics.
+|Name                       |Units|Instrument       |Label Key|Label Values                                                                                  |
+|---------------------------|-----|-----------------|---------|----------------------------------------------------------------------------------------------|
+|system.net.dropped\_packets|1    |SumObserver      |device   |(identifier)                                                                                  |
+|                           |     |                 |direction|transmit, receive                                                                             |
+|system.net.packets         |1    |SumObserver      |device   |(identifier)                                                                                  |
+|                           |     |                 |direction|transmit, receive                                                                             |
+|system.net.errors          |1    |SumObserver      |device   |(identifier)                                                                                  |
+|                           |     |                 |direction|transmit, receive                                                                             |
+|system<!--notlink-->.net.io|bytes|SumObserver      |device   |(identifier)                                                                                  |
+|                           |     |                 |direction|transmit, receive                                                                             |
+|system.net.connections     |1    |UpDownSumObserver|device   |(identifier)                                                                                  |
+|                           |     |                 |protocol |tcp, udp, [others](https://en.wikipedia.org/wiki/Transport_layer#Protocols)                   |
+|                           |     |                 |state    |[e.g. for tcp](https://en.wikipedia.org/wiki/Transmission_Control_Protocol#Protocol_operation)|
 
-|Name                       |Units|Instrument       |Label Key|Label Values                                                                                  |Linux/Windows Support|
-|---------------------------|-----|-----------------|---------|----------------------------------------------------------------------------------------------|---------------------|
-|system.net.dropped\_packets|1    |SumObserver      |direction|transmit                                                                                      |Both                 |
-|                           |     |                 |         |receive                                                                                       |Both                 |
-|system.net.packets         |1    |SumObserver      |direction|transmit                                                                                      |Both                 |
-|                           |     |                 |         |receive                                                                                       |Both                 |
-|system.net.errors          |1    |SumObserver      |direction|transmit                                                                                      |Both                 |
-|                           |     |                 |         |receive                                                                                       |Both                 |
-|system<!--notlink-->.net.io      |bytes|SumObserver      |direction|transmit                                                                                      |Both                 |
-|                           |     |                 |         |receive                                                                                       |Both                 |
-|system.net.connections     |1    |UpDownSumObserver|protocol |tcp                                                                                           |Both                 |
-|                           |     |                 |         |udp                                                                                           |Both                 |
-|                           |     |                 |         |[others](https://en.wikipedia.org/wiki/Transport_layer#Protocols)                             |Both                 |
-|                           |     |                 |state    |[e.g. for tcp](https://en.wikipedia.org/wiki/Transmission_Control_Protocol#Protocol_operation)|Both                 |
+#### OS Specific System Metrics - `system.{os}.`
+System level metrics specific to a certain operating system should be prefixed with `system.{os}.` and follow the hierarchies listed above for different entities like CPU, memory, and network.
 
-### OS Specific System Metrics - prefix `system.{os}`
-Operating system specific metrics
+TODO: example
 
-TODO
+### Standard Runtime Metrics - `runtime.`
+---
+
+Runtime environments vary widely in their terminology, implementation, and relative values for a given metric. For example, Go and Python are both garbage collected languages, but comparing heap usage between the two runtimes directly is not meaningful. For this reason, this OTEP does not propose any standard top-level runtime metrics. See [OTEP #109](https://github.com/open-telemetry/oteps/pull/108/files) for additional discussion.
+
+#### Runtime Specific Metrics - `runtime.{environment}.`
+Runtime level metrics specific to a certain runtime environment should be prefixed with `runtime.{environment}.` and follow the semantic conventions outlined in [Semantic Conventions](#semantic%20conventions).

--- a/text/0000-standard-system-metrics.md
+++ b/text/0000-standard-system-metrics.md
@@ -1,20 +1,20 @@
- mplegjkgStandard names for system/runtime metrics
+# Standard names for system/runtime metrics
 
-This OTEP proposes a set of standard names and semantic conventions for common system/runtime metrics collected by OpenTelemetry. The metric names and labels proposed here are common across the supported operating systems and runtime environments. This OTEP also includes semantic conventions for metrics specific to a particular OS or runtime.
+This OTEP proposes a set of standard names and semantic conventions for common system/runtime metrics collected by OpenTelemetry. The metric names proposed here are common across the supported operating systems and runtime environments. Also included are semantic conventions for metrics specific to a particular OS or runtime.
 
 This OTEP is largely based on the existing implementation in the OpenTelemetry Collector's [Host Metrics Receiver](https://github.com/open-telemetry/opentelemetry-collector/tree/1ad767e62f3dff6f62f32c7360b6fefe0fbf32ff/receiver/hostmetricsreceiver). The proposed names aim to make system/runtime metrics easily discoverable and unambiguous. See [OTEP #108](https://github.com/open-telemetry/oteps/pull/108/files) for additional motivation.
 
 ## Explanation
-There are some semantic conventions followed in this OTEP in order to keep naming consistent. Not all possible metrics are covered by these conventions, but they provide consistent names for many cases in the proposal:
-- **usage** - a measure of the amount an entity is used out of a known total amount should be called `entity.usage`. For example, `system.filesystem.usage` for the amount of disk spaced used. A measure of the amount of an unlimited resource consumed is differentiated from *usage*. This may be time, data, etc. *(I'm open to adjusting this to unit names or something else).*
-- **utilization** - a measure of the *percent* usage should be called `entity.utilization`. For example, `system.memory.utilization` for the percentage of memory in use. *(I'm open to a shorter name, but wanted to distinguish between usage as an amount and a percentage).*
-- **time** - a measure of the time taken should be called `entity.time`. For example, `system.cpu.time` with varying values of label `state` for idle, user, etc.
-- **io** - a measure of bidirectional data flow should be called `entity.io` and have labels for direction. For example, `system.net.io`.
+The following semantic conventions aim to keep naming consistent across different metrics. Not all possible metrics are covered by these conventions, but they provide guidelines for most of the cases in this proposal:
+- **usage** - an instrument that measures an amount used out of a known total amount should be called `entity.usage`. For example, `system.filesystem.usage` for the amount of disk spaced used. A measure of the amount of an unlimited resource consumed is differentiated from **usage**. This may be time, data, etc. *(I'm open to adjusting this to unit names or something else).*
+- **utilization** - an instrument that measures *percent* usage should be called `entity.utilization`. For example, `system.memory.utilization` for the percentage of memory in use. *(I'm open to a shorter name, but wanted to distinguish between usage as an amount and a percentage).*
+- **time** - an instrument that measures passage of time should be called `entity.time`. For example, `system.cpu.time` with varying values of label `state` for idle, user, etc.
+- **io** - an instrument that measures bidirectional data flow should be called `entity.io` and have labels for direction. For example, `system.net.io`.
 - Other metrics that do not fit the above descriptions may be named more freely. Units do not *need* to be specified in the names, but can be added if there is ambiguity. For example, `system.swap.page_faults` and `system.net.packets`. 
 
 ## Trade-offs and mitigations
 
-When choosing a metric name, there is a trade off between discoverability and ambiguity. For example, a metric called `system.cpu.load_average` is very discoverable, but the meaning of this metric is ambiguous. [Load average](https://en.wikipedia.org/wiki/Load_(computing)) is well defined on UNIX, but is not defined on Windows. Metric names must strike a balance between easy discovery and truthfulness of what the metric represents. 
+When choosing a metric name, there is a trade off between discoverability and ambiguity. For example, a metric called `system.cpu.load_average` is very discoverable, but the meaning of this metric is ambiguous. [Load average](https://en.wikipedia.org/wiki/Load_(computing)) is well defined on UNIX, but is not defined on Windows. Metric names must strike a balance between easy discovery and a concise summary of what the metric represents. 
 
 ## Prior art
 There is an existing metric naming proposal [here](https://docs.google.com/spreadsheets/d/1WlStcUe2eQoN1y_UF7TOd6Sw7aV_U0lFcLk5kBNxPsY/edit#gid=0). In addition, there are already a few implementations of system and/or runtime metric collection in OpenTelemetry:
@@ -37,18 +37,19 @@ There is an existing metric naming proposal [here](https://docs.google.com/sprea
   * Collects runtime CPU, memory, and GC metrics.
   * Makes use of labels, similar to the Collector.
   * [Overview of collected metrics](https://docs.google.com/spreadsheets/d/1r50cC9ass0A8SZIg2ZpLdvZf6HmQJsUSXFOu-rl4yaY/edit#gid=0).
+- **TODO: Java**
+- **TODO: Opencensus**
 
 
 ## Open questions
 
 - Should the individual runtimes have their specific naming conventions in the spec?
 - Establishing consistent base units for instruments of the same family e.g. seconds vs. milliseconds.
-- Should direct measurement be named for the units?
 
 ## Internal details
 The following standard metric names should be used in libraries instrumenting system/runtime metrics.
 
-### Standard System Metrics - prefix `system.`
+### Standard System Metrics - `system.`
 
 #### `system.cpu.`
 

--- a/text/0000-standard-system-metrics.md
+++ b/text/0000-standard-system-metrics.md
@@ -6,11 +6,10 @@ This OTEP is largely based on the existing implementation in the OpenTelemetry C
 
 ## Explanation
 There are some semantic conventions followed in this OTEP in order to keep naming consistent. Not all possible metrics are covered by these conventions, but they provide consistent names for many cases in the proposal:
-- **usage** - a measure of the amount an entity is used out of a known total amount should be called `entity.usage`. For example, `system.filesystem.usage` for the amount of disk spaced used. *(I'm open to adjusting this to unit names or something else).*
+- **usage** - a measure of the amount an entity is used out of a known total amount should be called `entity.usage`. For example, `system.filesystem.usage` for the amount of disk spaced used. A measure of the amount of an unlimited resource consumed is differentiated from *usage*. This may be time, data, etc. *(I'm open to adjusting this to unit names or something else).*
 - **utilization** - a measure of the *percent* usage should be called `entity.utilization`. For example, `system.memory.utilization` for the percentage of memory in use. *(I'm open to a shorter name, but wanted to distinguish between usage as an amount and a percentage).*
-- A measure of the amount of an unlimited resource consumed is differentiated from *usage*. This may be time, data, etc.
-  * **time** - a measure of the time taken should be called `entity.time`. For example, `system.cpu.time` with varying values of label `state` for idle, user, etc.
-  * **io** - a measure of bidirectional data flow should be called `entity.io` and have labels for direction. For example, `system.net.io`.
+- **time** - a measure of the time taken should be called `entity.time`. For example, `system.cpu.time` with varying values of label `state` for idle, user, etc.
+- **io** - a measure of bidirectional data flow should be called `entity.io` and have labels for direction. For example, `system.net.io`.
 - Other metrics that do not fit the above descriptions may be named more freely. Units do not *need* to be specified in the names, but can be added if there is ambiguity. For example, `system.swap.page_faults` and `system.net.packets`. 
 
 ## Trade-offs and mitigations

--- a/text/0000-standard-system-metrics.md
+++ b/text/0000-standard-system-metrics.md
@@ -1,3 +1,4 @@
+
 # Standard names for system/runtime metrics
 
 This OTEP proposes a set of standard names, labels, and semantic conventions for common system/runtime metrics collected by OpenTelemetry. The metric names proposed here are common across the supported operating systems and runtime environments. Also included are general semantic conventions for system/runtime metrics including those not specific to a particular OS or runtime.
@@ -9,13 +10,16 @@ This OTEP is largely based on the existing implementation in the OpenTelemetry C
 When choosing a metric name, there is a trade off between discoverability and ambiguity. For example, a metric called `system.cpu.load_average` is very discoverable, but the meaning of this metric is ambiguous. [Load average](https://en.wikipedia.org/wiki/Load_(computing)) is well defined on UNIX, but is not a standard metric on Windows. While discoverability is important, metric names must be unambiguous. 
 
 ## Prior art
-There is an existing metric naming proposal [here](https://docs.google.com/spreadsheets/d/1WlStcUe2eQoN1y_UF7TOd6Sw7aV_U0lFcLk5kBNxPsY/edit#gid=0). In addition, there are already a few implementations of system and/or runtime metric collection in OpenTelemetry:
+There are already a few implementations of system and/or runtime metric collection in OpenTelemetry:
 
+- **[OTEP #108](https://github.com/open-telemetry/oteps/pull/108/files)**
+  * Provides high level guidelines around naming metric instruments.
+  * Came out of a [prior proposal](https://docs.google.com/spreadsheets/d/1WlStcUe2eQoN1y_UF7TOd6Sw7aV_U0lFcLk5kBNxPsY/edit#gid=0) for system metrics?
 - **Collector**
   * [Host Metrics Receiver](https://github.com/open-telemetry/opentelemetry-collector/tree/1ad767e62f3dff6f62f32c7360b6fefe0fbf32ff/receiver/hostmetricsreceiver) generates metrics about the host system when run as an agent.
   * Currently is the most comprehensive implementation.
   * Collects system metrics for CPU, memory, swap, disks, filesystems, network, and load.
-  * Collects process metrics for CPU, memory, and disk usage.
+  * There are plans to collect process metrics for CPU, memory, and disk I/O.
   * Makes good use of labels rather than defining individual metrics.
   * [Overview of collected metrics](https://docs.google.com/spreadsheets/d/11qSmzD9e7PnzaJPYRFdkkKbjTLrAKmvyQpjBjpJsR2s).
 
@@ -25,18 +29,12 @@ There is an existing metric naming proposal [here](https://docs.google.com/sprea
   * [Overview of collected metrics](https://docs.google.com/spreadsheets/d/1r50cC9ass0A8SZIg2ZpLdvZf6HmQJsUSXFOu-rl4yaY/edit#gid=0).
 - **Python**
   * Python [has instrumentation](https://github.com/open-telemetry/opentelemetry-python/tree/master/ext/opentelemetry-ext-system-metrics) to collect some system and runtime metrics.
-  * Collects system CPU, memory, and network metrics
+  * Collects system CPU, memory, and network metrics.
   * Collects runtime CPU, memory, and GC metrics.
   * Makes use of labels, similar to the Collector.
   * [Overview of collected metrics](https://docs.google.com/spreadsheets/d/1r50cC9ass0A8SZIg2ZpLdvZf6HmQJsUSXFOu-rl4yaY/edit#gid=0).
 - **TODO: Java**
 - **TODO: Opencensus**
-
-
-## Open questions
-
-- Should the individual runtimes have their specific naming conventions in the spec?
-- Establishing consistent base units for instruments of the same family e.g. seconds vs. milliseconds. [Prometheus recommends using base units for compatibility](https://prometheus.io/docs/practices/naming/#base-units).
 
 ## Semantic Conventions
 The following semantic conventions aim to keep naming consistent across different metrics. Not all possible metrics are covered by these conventions, but they provide guidelines for most of the cases in this proposal:
@@ -44,11 +42,11 @@ The following semantic conventions aim to keep naming consistent across differen
 - **utilization** - an instrument that measures percent usage should be called `entity.utilization`. For example, `system.memory.utilization` for the percentage of memory in use. *(I'm open to a shorter name, but wanted to distinguish between usage as an amount and a percentage).*
 - **time** - an instrument that measures passage of time should be called `entity.time`. For example, `system.cpu.time` with varying values of label `state` for idle, user, etc.
 - **io** - an instrument that measures bidirectional data flow should be called `entity.io` and have labels for direction. For example, `system.net.io`.
-- Other metrics that do not fit the above descriptions may be named more freely. For example, `system.swap.page_faults` and `system.net.packets`. Units do not need to be specified in the names, but can be added if there is ambiguity.
+- Other metrics that do not fit the above descriptions may be named more freely. For example, `system.swap.page_faults` and `system.net.packets`. Units do not need to be specified in the names since they are included during instrument creation, but can be added if there is ambiguity.
 
 
 ## Internal details
-The following standard metric names should be used in libraries instrumenting system/runtime metrics.
+The following standard metric names should be used in libraries instrumenting system/runtime metrics (here is a [spreadsheet](https://docs.google.com/spreadsheets/d/1r50cC9ass0A8SZIg2ZpLdvZf6HmQJsUSXFOu-rl4yaY/edit#gid=973941697) of the tables below).
 
 ### Standard System Metrics - `system.`
 ---
@@ -98,7 +96,7 @@ The following standard metric names should be used in libraries instrumenting sy
 
 #### `system.filesystem.`
 
-**Description:** System level filesystem metrics. *I think usage/utilization should be consolidated into `system.disk` and the inodes metrics moved to a linux specific namespace.*
+**Description:** System level filesystem metrics. *I think usage/utilization should be consolidated into `system.disk`. Any filesystem specifics are probably scoped to the OS.*
 |Name                         |Units|Instrument       |Label Key|Label Values        |
 |-----------------------------|-----|-----------------|---------|--------------------|
 |system.filesystem.usage      |bytes|UpDownSumObserver|device   |(identifier)        |
@@ -124,14 +122,20 @@ The following standard metric names should be used in libraries instrumenting sy
 |                           |     |                 |state    |[e.g. for tcp](https://en.wikipedia.org/wiki/Transmission_Control_Protocol#Protocol_operation)|
 
 #### OS Specific System Metrics - `system.{os}.`
-System level metrics specific to a certain operating system should be prefixed with `system.{os}.` and follow the hierarchies listed above for different entities like CPU, memory, and network.
-
-TODO: example
+System level metrics specific to a certain operating system should be prefixed with `system.{os}.` and follow the hierarchies listed above for different entities like CPU, memory, and network. For example, metrics pertaining to Linux inodes would appear under `system.linux.filesystem.inodes.*`, reusing the `filesystem` name proposed above.
 
 ### Standard Runtime Metrics - `runtime.`
 ---
 
-Runtime environments vary widely in their terminology, implementation, and relative values for a given metric. For example, Go and Python are both garbage collected languages, but comparing heap usage between the two runtimes directly is not meaningful. For this reason, this OTEP does not propose any standard top-level runtime metrics. See [OTEP #109](https://github.com/open-telemetry/oteps/pull/108/files) for additional discussion.
+Runtime environments vary widely in their terminology, implementation, and relative values for a given metric. For example, Go and Python are both garbage collected languages, but comparing heap usage between the two runtimes directly is not meaningful. For this reason, this OTEP does not propose any standard top-level runtime metrics. See [OTEP #108](https://github.com/open-telemetry/oteps/pull/108/files) for additional discussion.
 
 #### Runtime Specific Metrics - `runtime.{environment}.`
-Runtime level metrics specific to a certain runtime environment should be prefixed with `runtime.{environment}.` and follow the semantic conventions outlined in [Semantic Conventions](#semantic%20conventions).
+Runtime level metrics specific to a certain runtime environment should be prefixed with `runtime.{environment}.` and follow the semantic conventions outlined in [Semantic Conventions](#semantic-conventions).
+
+
+## Open questions
+
+- Are there any common runtime metrics worth enumerating in [Standard Runtime Metrics](#standard-runtime-metrics---runtime)?
+- Should the individual runtimes have their specific naming conventions in the spec?
+- Process level metrics would be valuable, but how can one choose the processes to instrument? There is also the issue of labels for a process; if PID is included, the cardinality will grow unbounded since PIDs can always be different.
+- Establishing units for instruments of the same unit family e.g. seconds vs. milliseconds. [Prometheus recommends using base units for compatibility](https://prometheus.io/docs/practices/naming/#base-units).

--- a/text/0000-standard-system-metrics.md
+++ b/text/0000-standard-system-metrics.md
@@ -1,0 +1,93 @@
+# Standard names for system/runtime metrics
+
+This OTEP proposes a set of standard names and semantic conventions for
+common system/runtime metrics collected by OpenTelemetry. The metric names
+and labels proposed here are common across the supported operating systems
+and runtime environments. This OTEP also includes semantic conventions for
+metrics specific to a particular OS or runtime.
+
+This OTEP is largely based on the existing implementation in the
+OpenTelemetry Collector's [Host Metrics
+Receiver](https://github.com/open-telemetry/opentelemetry-collector/tree/1ad767e62f3dff6f62f32c7360b6fefe0fbf32ff/receiver/hostmetricsreceiver).
+The proposed names aim to make system/runtime metrics easily discoverable and
+unambiguous. See [OTEP
+#108](https://github.com/open-telemetry/oteps/pull/108/files) for additional
+motivation.
+
+## Trade-offs and mitigations
+
+TODO: find a better way to phrase this
+For a given metric, there is potentially a trade-off between the breadth of its scope and its meaning.
+
+## Prior art
+There is an existing metric naming proposal
+[here](https://docs.google.com/spreadsheets/d/1WlStcUe2eQoN1y_UF7TOd6Sw7aV_U0lFcLk5kBNxPsY/edit#gid=0).
+In addition, there are already a few implementations of system and/or runtime
+metric collection in OpenTelemetry:
+
+- **Collector**
+  * [Host Metrics
+  Receiver](https://github.com/open-telemetry/opentelemetry-collector/tree/1ad767e62f3dff6f62f32c7360b6fefe0fbf32ff/receiver/hostmetricsreceiver)
+  generates metrics about the host system when run as an agent.
+  * Currently is the most comprehensive implementation.
+  * Collects system metrics for CPU, memory, swap, disks, filesystems, network,
+and load.
+  * Collects process metrics for CPU, memory, and disk usage.
+  * Makes good use of labels rather than defining individual metrics.
+  * [Overview of collected metrics](https://docs.google.com/spreadsheets/d/11qSmzD9e7PnzaJPYRFdkkKbjTLrAKmvyQpjBjpJsR2s).
+
+- **Go**
+  * Go [has instrumentation](https://github.com/open-telemetry/opentelemetry-go-contrib/tree/master/instrumentation/runtime) to collect runtime metrics for GC, heap use, and goroutines. 
+  * This package does not export metrics with labels, instead exporting individual metrics.
+  * [Overview of collected metrics](https://docs.google.com/spreadsheets/d/1YqK66oWcW1iVo1fHwEb7JZWYGI_Dv3Bu3DQ6st-JMIY/edit#gid=0).
+- **Python**
+  * Python [has instrumentation](https://github.com/open-telemetry/opentelemetry-python/tree/master/ext/opentelemetry-ext-system-metrics) to collect some system and runtime metrics.
+  * Collects system CPU, memory, and network metrics
+  * Collects runtime CPU, memory, and GC metrics.
+  * Makes use of labels, similar to the Collector.
+  * [Overview of collected metrics](https://docs.google.com/spreadsheets/d/1YqK66oWcW1iVo1fHwEb7JZWYGI_Dv3Bu3DQ6st-JMIY/edit#gid=0).
+
+
+## Open questions
+
+- Should the individual runtimes have their specific naming conventions in the spec?
+
+---------
+## System
+
+**prefix:** `system.`
+
+**Description:** System level metrics
+
+|Name            |Units  |Instrument       |Label Key |Label Values|Linux/Windows Support|
+|----------------|-------|-----------------|----------|------------|---------------------|
+|system.cpu.time |seconds|SumObserver      |state     |idle        |Both                 |
+|                |       |                 |          |user        |Both                 |
+|                |       |                 |          |system      |Both                 |
+|                |       |                 |          |interrupt   |Both                 |
+|                |       |                 |          |nice        |Linux                |
+|                |       |                 |          |softirq     |Linux                |
+|                |       |                 |          |steal       |Linux                |
+|                |       |                 |          |wait        |Linux                |
+|system.cpu.usage|%      |UpDownSumObserver|(as above)|(as above)  |(as above)           |
+
+## Telemetry SDK
+
+**type:** `telemetry.sdk`
+
+**Description:** The telemetry SDK used to capture data recorded by the instrumentation libraries.
+
+The default OpenTelemetry SDK provided by the OpenTelemetry project MUST set `telemetry.sdk.name`
+to the value `opentelemetry`.
+
+If another SDK, like a fork or a vendor-provided implementation, is used, this SDK MUST set the attribute
+`telemetry.sdk.name` to the fully-qualified class or module name of this SDK's main entry point
+or another suitable identifier depending on the language.
+The identifier `opentelemetry` is reserved and MUST NOT be used in this case.
+The identifier SHOULD be stable across different versions of an implementation.
+
+| Attribute  | Description  | Example  | Required? |
+|---|---|---|---|
+| telemetry.sdk.name | The name of the telemetry SDK as defined above. | `opentelemetry` | No |
+| telemetry.sdk.language | The language of the telemetry SDK.<br/> One of the following values MUST be used, if one applies: "cpp", "dotnet", "erlang", "go", "java", "nodejs", "php", "python", "ruby", "webjs" | `java` | No |
+| telemetry.sdk.version | The version string of the telemetry SDK as defined in [Version Attributes](#version-attributes). | `semver:1.2.3` | No |

--- a/text/0000-standard-system-metrics.md
+++ b/text/0000-standard-system-metrics.md
@@ -1,8 +1,8 @@
 # Standard names for system/runtime metrics
 
-This OTEP proposes a set of standard names and semantic conventions for common system/runtime metrics collected by OpenTelemetry. The metric names proposed here are common across the supported operating systems and runtime environments. Also included are semantic conventions for metrics specific to a particular OS or runtime.
+This OTEP proposes a set of standard names, labels, and semantic conventions for common system/runtime metrics collected by OpenTelemetry. The metric names proposed here are common across the supported operating systems and runtime environments. Also included are general semantic conventions for system/runtime metrics including those not specific to a particular OS or runtime.
 
-This OTEP is largely based on the existing implementation in the OpenTelemetry Collector's [Host Metrics Receiver](https://github.com/open-telemetry/opentelemetry-collector/tree/1ad767e62f3dff6f62f32c7360b6fefe0fbf32ff/receiver/hostmetricsreceiver). The proposed names aim to make system/runtime metrics easily discoverable and unambiguous. See [OTEP #108](https://github.com/open-telemetry/oteps/pull/108/files) for additional motivation.
+This OTEP is largely based on the existing implementation in the OpenTelemetry Collector's [Host Metrics Receiver](https://github.com/open-telemetry/opentelemetry-collector/tree/1ad767e62f3dff6f62f32c7360b6fefe0fbf32ff/receiver/hostmetricsreceiver). The proposed names aim to make system/runtime metrics unambiguous and easily discoverable. See [OTEP #108](https://github.com/open-telemetry/oteps/pull/108/files) for additional motivation.
 
 ## Trade-offs and mitigations
 
@@ -36,15 +36,15 @@ There is an existing metric naming proposal [here](https://docs.google.com/sprea
 ## Open questions
 
 - Should the individual runtimes have their specific naming conventions in the spec?
-- Establishing consistent base units for instruments of the same family e.g. seconds vs. milliseconds.
+- Establishing consistent base units for instruments of the same family e.g. seconds vs. milliseconds. [Prometheus recommends using base units for compatibility](https://prometheus.io/docs/practices/naming/#base-units).
 
 ## Semantic Conventions
 The following semantic conventions aim to keep naming consistent across different metrics. Not all possible metrics are covered by these conventions, but they provide guidelines for most of the cases in this proposal:
 - **usage** - an instrument that measures an amount used out of a known total amount should be called `entity.usage`. For example, `system.filesystem.usage` for the amount of disk spaced used. A measure of the amount of an unlimited resource consumed is differentiated from **usage**. This may be time, data, etc. *(I'm open to adjusting this to unit names or something else).*
-- **utilization** - an instrument that measures *percent* usage should be called `entity.utilization`. For example, `system.memory.utilization` for the percentage of memory in use. *(I'm open to a shorter name, but wanted to distinguish between usage as an amount and a percentage).*
+- **utilization** - an instrument that measures percent usage should be called `entity.utilization`. For example, `system.memory.utilization` for the percentage of memory in use. *(I'm open to a shorter name, but wanted to distinguish between usage as an amount and a percentage).*
 - **time** - an instrument that measures passage of time should be called `entity.time`. For example, `system.cpu.time` with varying values of label `state` for idle, user, etc.
 - **io** - an instrument that measures bidirectional data flow should be called `entity.io` and have labels for direction. For example, `system.net.io`.
-- Other metrics that do not fit the above descriptions may be named more freely. Units do not *need* to be specified in the names, but can be added if there is ambiguity. For example, `system.swap.page_faults` and `system.net.packets`. 
+- Other metrics that do not fit the above descriptions may be named more freely. For example, `system.swap.page_faults` and `system.net.packets`. Units do not need to be specified in the names, but can be added if there is ambiguity.
 
 
 ## Internal details
@@ -102,9 +102,9 @@ The following standard metric names should be used in libraries instrumenting sy
 |Name                         |Units|Instrument       |Label Key|Label Values        |
 |-----------------------------|-----|-----------------|---------|--------------------|
 |system.filesystem.usage      |bytes|UpDownSumObserver|device   |(identifier)        |
+|                             |%    |                 |state    |used, free, reserved|
+|system.filesystem.utilization|     |UpDownSumObserver|device   |(identifier)        |
 |                             |     |                 |state    |used, free, reserved|
-|system.filesystem.utilization|%    |UpDownSumObserver|state    |used, free, reserved|
-|                             |     |                 |device   |(identifier)        |
 
 #### `system.net.`
 

--- a/text/0000-standard-system-metrics.md
+++ b/text/0000-standard-system-metrics.md
@@ -1,37 +1,29 @@
-# Standard names for system/runtime metrics
+ mplegjkgStandard names for system/runtime metrics
 
-This OTEP proposes a set of standard names and semantic conventions for
-common system/runtime metrics collected by OpenTelemetry. The metric names
-and labels proposed here are common across the supported operating systems
-and runtime environments. This OTEP also includes semantic conventions for
-metrics specific to a particular OS or runtime.
+This OTEP proposes a set of standard names and semantic conventions for common system/runtime metrics collected by OpenTelemetry. The metric names and labels proposed here are common across the supported operating systems and runtime environments. This OTEP also includes semantic conventions for metrics specific to a particular OS or runtime.
 
-This OTEP is largely based on the existing implementation in the
-OpenTelemetry Collector's [Host Metrics
-Receiver](https://github.com/open-telemetry/opentelemetry-collector/tree/1ad767e62f3dff6f62f32c7360b6fefe0fbf32ff/receiver/hostmetricsreceiver).
-The proposed names aim to make system/runtime metrics easily discoverable and
-unambiguous. See [OTEP
-#108](https://github.com/open-telemetry/oteps/pull/108/files) for additional
-motivation.
+This OTEP is largely based on the existing implementation in the OpenTelemetry Collector's [Host Metrics Receiver](https://github.com/open-telemetry/opentelemetry-collector/tree/1ad767e62f3dff6f62f32c7360b6fefe0fbf32ff/receiver/hostmetricsreceiver). The proposed names aim to make system/runtime metrics easily discoverable and unambiguous. See [OTEP #108](https://github.com/open-telemetry/oteps/pull/108/files) for additional motivation.
+
+## Explanation
+There are some semantic conventions followed in this OTEP in order to keep naming consistent. Not all possible metrics are covered by these conventions, but they provide consistent names for many cases in the proposal:
+- **usage** - a measure of the amount an entity is used out of a known total amount should be called `entity.usage`. For example, `system.filesystem.usage` for the amount of disk spaced used. *(I'm open to adjusting this to unit names or something else).*
+- **utilization** - a measure of the *percent* usage should be called `entity.utilization`. For example, `system.memory.utilization` for the percentage of memory in use. *(I'm open to a shorter name, but wanted to distinguish between usage as an amount and a percentage).*
+- A measure of the amount of an unlimited resource consumed is differentiated from *usage*. This may be time, data, etc.
+  * **time** - a measure of the time taken should be called `entity.time`. For example, `system.cpu.time` with varying values of label `state` for idle, user, etc.
+  * **io** - a measure of bidirectional data flow should be called `entity.io` and have labels for direction. For example, `system.net.io`.
+- Other metrics that do not fit the above descriptions may be named more freely. Units do not *need* to be specified in the names, but can be added if there is ambiguity. For example, `system.swap.page_faults` and `system.net.packets`. 
 
 ## Trade-offs and mitigations
 
-TODO: find a better way to phrase this
-For a given metric, there is potentially a trade-off between the breadth of its scope and its meaning.
+When choosing a metric name, there is a trade off between discoverability and ambiguity. For example, a metric called `system.cpu.load_average` is very discoverable, but the meaning of this metric is ambiguous. [Load average](https://en.wikipedia.org/wiki/Load_(computing)) is well defined on UNIX, but is not defined on Windows. Metric names must strike a balance between easy discovery and truthfulness of what the metric represents. 
 
 ## Prior art
-There is an existing metric naming proposal
-[here](https://docs.google.com/spreadsheets/d/1WlStcUe2eQoN1y_UF7TOd6Sw7aV_U0lFcLk5kBNxPsY/edit#gid=0).
-In addition, there are already a few implementations of system and/or runtime
-metric collection in OpenTelemetry:
+There is an existing metric naming proposal [here](https://docs.google.com/spreadsheets/d/1WlStcUe2eQoN1y_UF7TOd6Sw7aV_U0lFcLk5kBNxPsY/edit#gid=0). In addition, there are already a few implementations of system and/or runtime metric collection in OpenTelemetry:
 
 - **Collector**
-  * [Host Metrics
-  Receiver](https://github.com/open-telemetry/opentelemetry-collector/tree/1ad767e62f3dff6f62f32c7360b6fefe0fbf32ff/receiver/hostmetricsreceiver)
-  generates metrics about the host system when run as an agent.
+  * [Host Metrics Receiver](https://github.com/open-telemetry/opentelemetry-collector/tree/1ad767e62f3dff6f62f32c7360b6fefe0fbf32ff/receiver/hostmetricsreceiver) generates metrics about the host system when run as an agent.
   * Currently is the most comprehensive implementation.
-  * Collects system metrics for CPU, memory, swap, disks, filesystems, network,
-and load.
+  * Collects system metrics for CPU, memory, swap, disks, filesystems, network, and load.
   * Collects process metrics for CPU, memory, and disk usage.
   * Makes good use of labels rather than defining individual metrics.
   * [Overview of collected metrics](https://docs.google.com/spreadsheets/d/11qSmzD9e7PnzaJPYRFdkkKbjTLrAKmvyQpjBjpJsR2s).
@@ -39,55 +31,122 @@ and load.
 - **Go**
   * Go [has instrumentation](https://github.com/open-telemetry/opentelemetry-go-contrib/tree/master/instrumentation/runtime) to collect runtime metrics for GC, heap use, and goroutines. 
   * This package does not export metrics with labels, instead exporting individual metrics.
-  * [Overview of collected metrics](https://docs.google.com/spreadsheets/d/1YqK66oWcW1iVo1fHwEb7JZWYGI_Dv3Bu3DQ6st-JMIY/edit#gid=0).
+  * [Overview of collected metrics](https://docs.google.com/spreadsheets/d/1r50cC9ass0A8SZIg2ZpLdvZf6HmQJsUSXFOu-rl4yaY/edit#gid=0).
 - **Python**
   * Python [has instrumentation](https://github.com/open-telemetry/opentelemetry-python/tree/master/ext/opentelemetry-ext-system-metrics) to collect some system and runtime metrics.
   * Collects system CPU, memory, and network metrics
   * Collects runtime CPU, memory, and GC metrics.
   * Makes use of labels, similar to the Collector.
-  * [Overview of collected metrics](https://docs.google.com/spreadsheets/d/1YqK66oWcW1iVo1fHwEb7JZWYGI_Dv3Bu3DQ6st-JMIY/edit#gid=0).
+  * [Overview of collected metrics](https://docs.google.com/spreadsheets/d/1r50cC9ass0A8SZIg2ZpLdvZf6HmQJsUSXFOu-rl4yaY/edit#gid=0).
 
 
 ## Open questions
 
 - Should the individual runtimes have their specific naming conventions in the spec?
+- Establishing consistent base units for instruments of the same family e.g. seconds vs. milliseconds.
+- Should direct measurement be named for the units?
 
----------
-## System
+## Internal details
+The following standard metric names should be used in libraries instrumenting system/runtime metrics.
 
-**prefix:** `system.`
+### Standard System Metrics - prefix `system.`
 
-**Description:** System level metrics
+#### `system.cpu.`
 
-|Name            |Units  |Instrument       |Label Key |Label Values|Linux/Windows Support|
-|----------------|-------|-----------------|----------|------------|---------------------|
-|system.cpu.time |seconds|SumObserver      |state     |idle        |Both                 |
-|                |       |                 |          |user        |Both                 |
-|                |       |                 |          |system      |Both                 |
-|                |       |                 |          |interrupt   |Both                 |
-|                |       |                 |          |nice        |Linux                |
-|                |       |                 |          |softirq     |Linux                |
-|                |       |                 |          |steal       |Linux                |
-|                |       |                 |          |wait        |Linux                |
-|system.cpu.usage|%      |UpDownSumObserver|(as above)|(as above)  |(as above)           |
+**Description:** System level processor metrics.
 
-## Telemetry SDK
+|Name                  |Units  |Instrument       |Label Key |Label Values|Linux/Windows Support|
+|----------------------|-------|-----------------|----------|------------|---------------------|
+|system.cpu.time       |seconds|SumObserver      |state     |idle        |Both                 |
+|                      |       |                 |          |user        |Both                 |
+|                      |       |                 |          |system      |Both                 |
+|                      |       |                 |          |interrupt   |Both                 |
+|                      |       |                 |          |nice        |Linux                |
+|                      |       |                 |          |softirq     |Linux                |
+|                      |       |                 |          |steal       |Linux                |
+|                      |       |                 |          |wait        |Linux                |
+|system.cpu.utilization|%      |UpDownSumObserver|(as above)|(as above)  |(as above)           |
 
-**type:** `telemetry.sdk`
+#### `system.memory.`
 
-**Description:** The telemetry SDK used to capture data recorded by the instrumentation libraries.
+**Description:** System level memory metrics.
 
-The default OpenTelemetry SDK provided by the OpenTelemetry project MUST set `telemetry.sdk.name`
-to the value `opentelemetry`.
+|Name                     |Units|Instrument       |Label Key |Label Values       |Linux/Windows Support|
+|-------------------------|-----|-----------------|----------|-------------------|---------------------|
+|system.memory.usage      |bytes|UpDownSumObserver|state     |used               |Both                 |
+|                         |     |                 |          |free               |Both                 |
+|                         |     |                 |          |buffered           |Linux                |
+|                         |     |                 |          |cached             |Linux                |
+|                         |     |                 |          |slab\_reclaimable  |Linux                |
+|                         |     |                 |          |slab\_unreclaimable|Linux                |
+|system.memory.utilization|%    |UpDownSumObserver|(as above)|(as above)         |(as above)           |
 
-If another SDK, like a fork or a vendor-provided implementation, is used, this SDK MUST set the attribute
-`telemetry.sdk.name` to the fully-qualified class or module name of this SDK's main entry point
-or another suitable identifier depending on the language.
-The identifier `opentelemetry` is reserved and MUST NOT be used in this case.
-The identifier SHOULD be stable across different versions of an implementation.
+#### `system.swap.`
 
-| Attribute  | Description  | Example  | Required? |
-|---|---|---|---|
-| telemetry.sdk.name | The name of the telemetry SDK as defined above. | `opentelemetry` | No |
-| telemetry.sdk.language | The language of the telemetry SDK.<br/> One of the following values MUST be used, if one applies: "cpp", "dotnet", "erlang", "go", "java", "nodejs", "php", "python", "ruby", "webjs" | `java` | No |
-| telemetry.sdk.version | The version string of the telemetry SDK as defined in [Version Attributes](#version-attributes). | `semver:1.2.3` | No |
+**Description:** System level swap/paging metrics.
+
+|Name                    |Units|Instrument       |Label Key |Label Values|Linux/Windows Support|
+|------------------------|-----|-----------------|----------|------------|---------------------|
+|system.swap.usage       |pages|UpDownSumObserver|state     |used        |Both                 |
+|                        |     |                 |          |free        |Both                 |
+|system.swap.utilization |%    |UpDownSumObserver|(as above)|(as above)  |(as above)           |
+|system.swap.page\_faults|1    |SumObserver      |type      |major       |Linux                |
+|                        |     |                 |          |minor       |Linux                |
+|system.swap.paging\_ops |1    |SumObserver      |type      |major       |Both                 |
+|                        |     |                 |          |minor       |Linux                |
+|                        |     |                 |direction |in          |Both                 |
+|                        |     |                 |          |out         |Both                 |
+
+
+#### `system.disk.`
+
+**Description:** System level disk performance metrics.
+
+|Name                        |Units|Instrument |Label Key|Label Values|Linux/Windows Support|
+|----------------------------|-----|-----------|---------|------------|---------------------|
+|system.disk.io<!--notlink-->|bytes|SumObserver|direction|read        |Both                 |
+|                            |     |           |         |write       |Both                 |
+|system.disk.ops             |1    |SumObserver|direction|read        |Both                 |
+|                            |     |           |         |write       |Both                 |
+|system.disk.time            |s    |SumObserver|direction|read        |Both                 |
+|                            |     |           |         |write       |Both                 |
+|system.disk.merged          |1    |SumObserver|direction|read        |Linux                |
+|                            |     |           |         |write       |Linux                |
+
+#### `system.filesystem.`
+
+**Description:** System level filesystem metrics. *I think usage/utilization should be consolidated into `system.disk` and the inodes metrics moved to a linux specific namespace.*
+
+|Name                                |Units|Instrument       |Label Key |Label Values|Linux/Windows Support|
+|------------------------------------|-----|-----------------|----------|------------|---------------------|
+|system.filesystem.usage             |bytes|UpDownSumObserver|state     |used        |Both                 |
+|                                    |     |                 |          |free        |Both                 |
+|                                    |     |                 |          |reserved    |Linux                |
+|system.filesystem.utilization       |%    |UpDownSumObserver|(as above)|(as above)  |(as above)           |
+|system.filesystem.inodes.used       |1    |UpDownSumObserver|state     |used        |Linux                |
+|                                    |     |                 |          |free        |Linux                |
+|system.filesystem.inodes.utilization|%    |UpDownSumObserver|(as above)|(as above)  |(as above)           |
+
+#### `system.net.`
+
+**Description:** System level network metrics.
+
+|Name                       |Units|Instrument       |Label Key|Label Values                                                                                  |Linux/Windows Support|
+|---------------------------|-----|-----------------|---------|----------------------------------------------------------------------------------------------|---------------------|
+|system.net.dropped\_packets|1    |SumObserver      |direction|transmit                                                                                      |Both                 |
+|                           |     |                 |         |receive                                                                                       |Both                 |
+|system.net.packets         |1    |SumObserver      |direction|transmit                                                                                      |Both                 |
+|                           |     |                 |         |receive                                                                                       |Both                 |
+|system.net.errors          |1    |SumObserver      |direction|transmit                                                                                      |Both                 |
+|                           |     |                 |         |receive                                                                                       |Both                 |
+|system<!--notlink-->.net.io      |bytes|SumObserver      |direction|transmit                                                                                      |Both                 |
+|                           |     |                 |         |receive                                                                                       |Both                 |
+|system.net.connections     |1    |UpDownSumObserver|protocol |tcp                                                                                           |Both                 |
+|                           |     |                 |         |udp                                                                                           |Both                 |
+|                           |     |                 |         |[others](https://en.wikipedia.org/wiki/Transport_layer#Protocols)                             |Both                 |
+|                           |     |                 |state    |[e.g. for tcp](https://en.wikipedia.org/wiki/Transmission_Control_Protocol#Protocol_operation)|Both                 |
+
+### OS Specific System Metrics - prefix `system.{os}`
+Operating system specific metrics
+
+TODO

--- a/text/0119-standard-system-metrics.md
+++ b/text/0119-standard-system-metrics.md
@@ -57,72 +57,70 @@ The following standard metric names should be used in libraries instrumenting sy
 #### `system.cpu.`
 
 **Description:** System level processor metrics.
-|Name                  |Units  |Instrument       |Label Key|Label Values                       |
-|----------------------|-------|-----------------|---------|-----------------------------------|
-|system.cpu.time       |seconds|SumObserver      |state    |idle, user, system, interrupt, etc.|
-|                      |       |                 |cpu      |1 - #cores                         |
-|system.cpu.utilization|%      |UpDownSumObserver|state    |idle, user, system, interrupt, etc.|
-|                      |       |                 |cpu      |1 - #cores                         |
+|Name                  |Units  |Instrument Type  |Value Type|Label Key|Label Values                       |
+|----------------------|-------|-----------------|----------|---------|-----------------------------------|
+|system.cpu.time       |seconds|SumObserver      |Double    |state    |idle, user, system, interrupt, etc.|
+|                      |       |                 |          |cpu      |1 - #cores                         |
+|system.cpu.utilization|1      |UpDownSumObserver|Double    |state    |idle, user, system, interrupt, etc.|
+|                      |       |                 |          |cpu      |1 - #cores                         |
 
 #### `system.memory.`
 
 **Description:** System level memory metrics.
-|Name                     |Units|Instrument       |Label Key|Label Values            |
-|-------------------------|-----|-----------------|---------|------------------------|
-|system.memory.usage      |bytes|UpDownSumObserver|state    |used, free, cached, etc.|
-|system.memory.utilization|%    |UpDownSumObserver|state    |used, free, cached, etc.|
+|Name                     |Units|Instrument Type  |Value Type|Label Key|Label Values            |
+|-------------------------|-----|-----------------|----------|---------|------------------------|
+|system.memory.usage      |bytes|UpDownSumObserver|Int64     |state    |used, free, cached, etc.|
+|system.memory.utilization|1    |UpDownSumObserver|Double    |state    |used, free, cached, etc.|
 
 #### `system.swap.`
 
 **Description:** System level swap/paging metrics.
-|Name                    |Units|Instrument       |Label Key|Label Values|
-|------------------------|-----|-----------------|---------|------------|
-|system.swap.usage       |pages|UpDownSumObserver|state    |used, free  |
-|system.swap.utilization |%    |UpDownSumObserver|state    |used, free  |
-|system.swap.page\_faults|1    |SumObserver      |type     |major, minor|
-|system.swap.paging\_ops |1    |SumObserver      |type     |major, minor|
-|                        |     |                 |direction|in, out     |
+|Name                    |Units |Instrument Type  |Value Type|Label Key|Label Values|
+|------------------------|------|-----------------|----------|---------|------------|
+|system.swap.usage       |pages |UpDownSumObserver|Int64     |state    |used, free  |
+|system.swap.utilization |1     |UpDownSumObserver|Double    |state    |used, free  |
+|system.swap.page\_faults|faults|SumObserver      |Int64     |type     |major, minor|
+|system.swap.paging\_ops |ops   |SumObserver      |Int64     |type     |major, minor|
+|                        |      |                 |          |direction|in, out     |
 
 #### `system.disk.`
 
 **Description:** System level disk performance metrics.
-|Name                        |Units|Instrument |Label Key|Label Values|
-|----------------------------|-----|-----------|---------|------------|
-|system.disk.io<!--notlink-->|bytes|SumObserver|device   |(identifier)|
-|                            |     |           |direction|read, write |
-|system.disk.ops             |1    |SumObserver|device   |(identifier)|
-|                            |     |           |direction|read, write |
-|system.disk.time            |s    |SumObserver|device   |(identifier)|
-|                            |     |           |direction|read, write |
-|system.disk.merged          |1    |SumObserver|device   |(identifier)|
-|                            |     |           |direction|read, write |
+|Name                        |Units  |Instrument Type|Value Type|Label Key|Label Values|
+|----------------------------|-------|---------------|----------|---------|------------|
+|system.disk.io<!--notlink-->|bytes  |SumObserver    |Int64     |device   |(identifier)|
+|                            |       |               |          |direction|read, write |
+|system.disk.ops             |ops    |SumObserver    |Int64     |device   |(identifier)|
+|                            |       |               |          |direction|read, write |
+|system.disk.time            |seconds|SumObserver    |Double    |device   |(identifier)|
+|                            |       |               |          |direction|read, write |
 
 #### `system.filesystem.`
 
 **Description:** System level filesystem metrics. *I think usage/utilization should be consolidated into `system.disk`. Any filesystem specifics are probably scoped to the OS.*
-|Name                         |Units|Instrument       |Label Key|Label Values        |
-|-----------------------------|-----|-----------------|---------|--------------------|
-|system.filesystem.usage      |bytes|UpDownSumObserver|device   |(identifier)        |
-|                             |%    |                 |state    |used, free, reserved|
-|system.filesystem.utilization|     |UpDownSumObserver|device   |(identifier)        |
-|                             |     |                 |state    |used, free, reserved|
+|Name                         |Units|Instrument Type  |Value Type|Label Key|Label Values        |
+|-----------------------------|-----|-----------------|----------|---------|--------------------|
+|system.filesystem.usage      |bytes|UpDownSumObserver|Int64     |device   |(identifier)        |
+|                             |     |                 |          |state    |used, free, reserved|
+|system.filesystem.utilization|1    |UpDownSumObserver|Double    |device   |(identifier)        |
+|                             |     |                 |          |state    |used, free, reserved|
 
 #### `system.net.`
 
 **Description:** System level network metrics.
-|Name                       |Units|Instrument       |Label Key|Label Values                                                                                  |
-|---------------------------|-----|-----------------|---------|----------------------------------------------------------------------------------------------|
-|system.net.dropped\_packets|1    |SumObserver      |device   |(identifier)                                                                                  |
-|                           |     |                 |direction|transmit, receive                                                                             |
-|system.net.packets         |1    |SumObserver      |device   |(identifier)                                                                                  |
-|                           |     |                 |direction|transmit, receive                                                                             |
-|system.net.errors          |1    |SumObserver      |device   |(identifier)                                                                                  |
-|                           |     |                 |direction|transmit, receive                                                                             |
-|system<!--notlink-->.net.io|bytes|SumObserver      |device   |(identifier)                                                                                  |
-|                           |     |                 |direction|transmit, receive                                                                             |
-|system.net.connections     |1    |UpDownSumObserver|device   |(identifier)                                                                                  |
-|                           |     |                 |protocol |tcp, udp, [others](https://en.wikipedia.org/wiki/Transport_layer#Protocols)                   |
-|                           |     |                 |state    |[e.g. for tcp](https://en.wikipedia.org/wiki/Transmission_Control_Protocol#Protocol_operation)|
+|Name                       |Units      |Instrument Type  |Value Type|Label Key|Label Values                                                                                  |
+|---------------------------|-----------|-----------------|----------|---------|----------------------------------------------------------------------------------------------|
+|system.net.dropped\_packets|packets    |SumObserver      |Int64     |device   |(identifier)                                                                                  |
+|                           |           |                 |          |direction|transmit, receive                                                                             |
+|system.net.packets         |packets    |SumObserver      |Int64     |device   |(identifier)                                                                                  |
+|                           |           |                 |          |direction|transmit, receive                                                                             |
+|system.net.errors          |errors     |SumObserver      |Int64     |device   |(identifier)                                                                                  |
+|                           |           |                 |          |direction|transmit, receive                                                                             |
+|system<!--notlink-->.net.io|bytes      |SumObserver      |Int64     |device   |(identifier)                                                                                  |
+|                           |           |                 |          |direction|transmit, receive                                                                             |
+|system.net.connections     |connections|UpDownSumObserver|Int64     |device   |(identifier)                                                                                  |
+|                           |           |                 |          |protocol |tcp, udp, [others](https://en.wikipedia.org/wiki/Transport_layer#Protocols)                   |
+|                           |           |                 |          |state    |[e.g. for tcp](https://en.wikipedia.org/wiki/Transmission_Control_Protocol#Protocol_operation)|
 
 #### OS Specific System Metrics - `system.{os}.`
 
@@ -136,11 +134,10 @@ Runtime environments vary widely in their terminology, implementation, and relat
 
 #### Runtime Specific Metrics - `runtime.{environment}.`
 
-Runtime level metrics specific to a certain runtime environment should be prefixed with `runtime.{environment}.` and follow the semantic conventions outlined in [Semantic Conventions](#semantic-conventions).
+Runtime level metrics specific to a certain runtime environment should be prefixed with `runtime.{environment}.` and follow the semantic conventions outlined in [Semantic Conventions](#semantic-conventions). For example, Go runtime metrics use `runtime.go.` as a prefix.
+
+Some programming languages have multiple runtime environments that vary significantly in their implementation, for example [Python has many implementations](https://wiki.python.org/moin/PythonImplementations). For these languages, consider using specific `environment` prefixes to avoid ambiguity, like `runtime.cpython.` and `runtime.pypy.`.
 
 ## Open questions
 
-- Are there any common runtime metrics worth enumerating in [Standard Runtime Metrics](#standard-runtime-metrics---runtime)?
 - Should the individual runtimes have their specific naming conventions in the spec?
-- Process level metrics would be valuable, but how can one choose the processes to instrument? There is also the issue of labels for a process; if PID is included, the cardinality will grow unbounded since PIDs can always be different.
-- Establishing units for instruments of the same unit family e.g. seconds vs. milliseconds. [Prometheus recommends using base units for compatibility](https://prometheus.io/docs/practices/naming/#base-units).

--- a/text/0119-standard-system-metrics.md
+++ b/text/0119-standard-system-metrics.md
@@ -1,4 +1,3 @@
-
 # Standard names for system/runtime metrics
 
 This OTEP proposes a set of standard names, labels, and semantic conventions for common system/runtime metrics collected by OpenTelemetry. The metric names proposed here are common across the supported operating systems and runtime environments. Also included are general semantic conventions for system/runtime metrics including those not specific to a particular OS or runtime.

--- a/text/0119-standard-system-metrics.md
+++ b/text/0119-standard-system-metrics.md
@@ -145,3 +145,6 @@ Some programming languages have multiple runtime environments that vary signific
   1. Top level: `system.filesystem.inodes.*`
   2. UNIX family level: `system.unix.filesystem.inodes.*`
   3. One for each UNIX OS: `system.linux.filesystem.inodes.*`, `system.freebsd.filesystem.inodes.*`, `system.netbsd.filesystem.inodes.*`, etc.
+- Should instrument names be versioned e.g. `v1.system.cpu.usage`?
+  * Some telemetry backends use a strict schema for metrics and their labels (e.g. Google Cloud Monitoring with [MetricDescriptors](https://cloud.google.com/monitoring/api/v3/metrics-details#intro-metdesc)), so changes to the instruments proposed in this document could break ingestion of new telemetry data.
+  * Should the exporters for such backends be responsible for handling this? How could this be implemented in the exporter without additional information?

--- a/text/0119-standard-system-metrics.md
+++ b/text/0119-standard-system-metrics.md
@@ -41,8 +41,8 @@ The following semantic conventions aim to keep naming consistent. Not all possib
 - **usage** - an instrument that measures an amount used out of a known total amount should be called `entity.usage`. For example, `system.filesystem.usage` for the amount of disk spaced used. A measure of the amount of an unlimited resource consumed is differentiated from **usage**. This may be time, data, etc.
 - **utilization** - an instrument that measures a *value ratio* of usage (like percent, but in the range `[0, 1]`) should be called `entity.utilization`. For example, `system.memory.utilization` for the ratio of memory in use.
 - **time** - an instrument that measures passage of time should be called `entity.time`. For example, `system.cpu.time` with varying values of label `state` for idle, user, etc.
-- **io** - an instrument that measures bidirectional data flow should be called `entity.io` and have labels for direction. For example, `system.net.io`.
-- Other instruments that do not fit the above descriptions may be named more freely. For example, `system.swap.page_faults` and `system.net.packets`. Units do not need to be specified in the names since they are included during instrument creation, but can be added if there is ambiguity.
+- **io** - an instrument that measures bidirectional data flow should be called `entity.io` and have labels for direction. For example, `system.network.io`.
+- Other instruments that do not fit the above descriptions may be named more freely. For example, `system.swap.page_faults` and `system.network.packets`. Units do not need to be specified in the names since they are included during instrument creation, but can be added if there is ambiguity.
 
 ## Internal details
 
@@ -75,25 +75,27 @@ In the tables below, units of `1` refer to a ratio value that is always in the r
 #### `system.swap.`
 
 **Description:** System level swap/paging metrics.
-|Name                    |Units |Instrument Type  |Value Type|Label Key|Label Values|
-|------------------------|------|-----------------|----------|---------|------------|
-|system.swap.usage       |pages |UpDownSumObserver|Int64     |state    |used, free  |
-|system.swap.utilization |1     |UpDownSumObserver|Double    |state    |used, free  |
-|system.swap.page\_faults|faults|SumObserver      |Int64     |type     |major, minor|
-|system.swap.paging\_ops |ops   |SumObserver      |Int64     |type     |major, minor|
-|                        |      |                 |          |direction|in, out     |
+|Name                        |Units     |Instrument Type  |Value Type|Label Key|Label Values|
+|----------------------------|----------|-----------------|----------|---------|------------|
+|system.swap.usage           |pages     |UpDownSumObserver|Int64     |state    |used, free  |
+|system.swap.utilization     |1         |UpDownSumObserver|Double    |state    |used, free  |
+|system.swap.page\_faults    |faults    |SumObserver      |Int64     |type     |major, minor|
+|system.swap.page\_operations|operations|SumObserver      |Int64     |type     |major, minor|
+|                            |          |                 |          |direction|in, out     |
 
 #### `system.disk.`
 
 **Description:** System level disk performance metrics.
-|Name                        |Units  |Instrument Type|Value Type|Label Key|Label Values|
-|----------------------------|-------|---------------|----------|---------|------------|
-|system.disk.io<!--notlink-->|bytes  |SumObserver    |Int64     |device   |(identifier)|
-|                            |       |               |          |direction|read, write |
-|system.disk.ops             |ops    |SumObserver    |Int64     |device   |(identifier)|
-|                            |       |               |          |direction|read, write |
-|system.disk.time            |seconds|SumObserver    |Double    |device   |(identifier)|
-|                            |       |               |          |direction|read, write |
+|Name                        |Units     |Instrument Type|Value Type|Label Key|Label Values|
+|----------------------------|----------|---------------|----------|---------|------------|
+|system.disk.io<!--notlink-->|bytes     |SumObserver    |Int64     |device   |(identifier)|
+|                            |          |               |          |direction|read, write |
+|system.disk.operations      |operations|SumObserver    |Int64     |device   |(identifier)|
+|                            |          |               |          |direction|read, write |
+|system.disk.time            |seconds   |SumObserver    |Double    |device   |(identifier)|
+|                            |          |               |          |direction|read, write |
+|system.disk.merged          |1         |SumObserver    |Int64     |device   |(identifier)|
+|                            |          |               |          |direction|read, write |
 
 #### `system.filesystem.`
 
@@ -105,26 +107,26 @@ In the tables below, units of `1` refer to a ratio value that is always in the r
 |system.filesystem.utilization|1    |UpDownSumObserver|Double    |device   |(identifier)        |
 |                             |     |                 |          |state    |used, free, reserved|
 
-#### `system.net.`
+#### `system.network.`
 
 **Description:** System level network metrics.
-|Name                       |Units      |Instrument Type  |Value Type|Label Key|Label Values                                                                                  |
-|---------------------------|-----------|-----------------|----------|---------|----------------------------------------------------------------------------------------------|
-|system.net.dropped\_packets|packets    |SumObserver      |Int64     |device   |(identifier)                                                                                  |
-|                           |           |                 |          |direction|transmit, receive                                                                             |
-|system.net.packets         |packets    |SumObserver      |Int64     |device   |(identifier)                                                                                  |
-|                           |           |                 |          |direction|transmit, receive                                                                             |
-|system.net.errors          |errors     |SumObserver      |Int64     |device   |(identifier)                                                                                  |
-|                           |           |                 |          |direction|transmit, receive                                                                             |
-|system<!--notlink-->.net.io|bytes      |SumObserver      |Int64     |device   |(identifier)                                                                                  |
-|                           |           |                 |          |direction|transmit, receive                                                                             |
-|system.net.connections     |connections|UpDownSumObserver|Int64     |device   |(identifier)                                                                                  |
-|                           |           |                 |          |protocol |tcp, udp, [others](https://en.wikipedia.org/wiki/Transport_layer#Protocols)                   |
-|                           |           |                 |          |state    |[e.g. for tcp](https://en.wikipedia.org/wiki/Transmission_Control_Protocol#Protocol_operation)|
+|Name                           |Units      |Instrument Type  |Value Type|Label Key|Label Values                                                                                  |
+|-------------------------------|-----------|-----------------|----------|---------|----------------------------------------------------------------------------------------------|
+|system.network.dropped\_packets|packets    |SumObserver      |Int64     |device   |(identifier)                                                                                  |
+|                               |           |                 |          |direction|transmit, receive                                                                             |
+|system.network.packets         |packets    |SumObserver      |Int64     |device   |(identifier)                                                                                  |
+|                               |           |                 |          |direction|transmit, receive                                                                             |
+|system.network.errors          |errors     |SumObserver      |Int64     |device   |(identifier)                                                                                  |
+|                               |           |                 |          |direction|transmit, receive                                                                             |
+|system<!--notlink-->.network.io|bytes      |SumObserver      |Int64     |device   |(identifier)                                                                                  |
+|                               |           |                 |          |direction|transmit, receive                                                                             |
+|system.network.connections     |connections|UpDownSumObserver|Int64     |device   |(identifier)                                                                                  |
+|                               |           |                 |          |protocol |tcp, udp, [others](https://en.wikipedia.org/wiki/Transport_layer#Protocols)                   |
+|                               |           |                 |          |state    |[e.g. for tcp](https://en.wikipedia.org/wiki/Transmission_Control_Protocol#Protocol_operation)|
 
 #### OS Specific System Metrics - `system.{os}.`
 
-Instrument names for system level metrics specific to a certain operating system should be prefixed with `system.{os}.` and follow the hierarchies listed above for different entities like CPU, memory, and network. For example, an instrument for counting the number of Linux merged disk operations (see [here](https://unix.stackexchange.com/questions/462704/iostat-what-is-exactly-the-concept-of-merge) and [here](https://man7.org/linux/man-pages/man1/iostat.1.html)) could be named `system.linux.disk.merged_ops`, reusing the `disk` name proposed above.
+Instrument names for system level metrics specific to a certain operating system should be prefixed with `system.{os}.` and follow the hierarchies listed above for different entities like CPU, memory, and network. For example, an instrument for counting the number of Linux merged disk operations (see [here](https://unix.stackexchange.com/questions/462704/iostat-what-is-exactly-the-concept-of-merge) and [here](https://man7.org/linux/man-pages/man1/iostat.1.html)) could be named `system.linux.disk.merged_operations`, reusing the `disk` name proposed above.
 
 ### Standard Runtime Metrics - `runtime.`
 

--- a/text/0119-standard-system-metrics.md
+++ b/text/0119-standard-system-metrics.md
@@ -145,6 +145,3 @@ Some programming languages have multiple runtime environments that vary signific
   1. Top level: `system.filesystem.inodes.*`
   2. UNIX family level: `system.unix.filesystem.inodes.*`
   3. One for each UNIX OS: `system.linux.filesystem.inodes.*`, `system.freebsd.filesystem.inodes.*`, `system.netbsd.filesystem.inodes.*`, etc.
-- Should instrument names be versioned e.g. `v1.system.cpu.usage`?
-  * Some telemetry backends use a strict schema for metrics and their labels (e.g. Google Cloud Monitoring with [MetricDescriptors](https://cloud.google.com/monitoring/api/v3/metrics-details#intro-metdesc)), so changes to the instruments proposed in this document could break ingestion of new telemetry data.
-  * Should the exporters for such backends be responsible for handling this? How could this be implemented in the exporter without additional information?

--- a/text/0119-standard-system-metrics.md
+++ b/text/0119-standard-system-metrics.md
@@ -6,9 +6,10 @@ This OTEP is largely based on the existing implementation in the OpenTelemetry C
 
 ## Trade-offs and mitigations
 
-When choosing a metric name, there is a trade off between discoverability and ambiguity. For example, a metric called `system.cpu.load_average` is very discoverable, but the meaning of this metric is ambiguous. [Load average](https://en.wikipedia.org/wiki/Load_(computing)) is well defined on UNIX, but is not a standard metric on Windows. While discoverability is important, metric names must be unambiguous. 
+When choosing a metric name, there is a trade off between discoverability and ambiguity. For example, a metric called `system.cpu.load_average` is very discoverable, but the meaning of this metric is ambiguous. [Load average](https://en.wikipedia.org/wiki/Load_(computing)) is well defined on UNIX, but is not a standard metric on Windows. While discoverability is important, metric names must be unambiguous.
 
 ## Prior art
+
 There are already a few implementations of system and/or runtime metric collection in OpenTelemetry:
 
 - **[OTEP #108](https://github.com/open-telemetry/oteps/pull/108/files)**
@@ -23,7 +24,7 @@ There are already a few implementations of system and/or runtime metric collecti
   * [Overview of collected metrics](https://docs.google.com/spreadsheets/d/11qSmzD9e7PnzaJPYRFdkkKbjTLrAKmvyQpjBjpJsR2s).
 
 - **Go**
-  * Go [has instrumentation](https://github.com/open-telemetry/opentelemetry-go-contrib/tree/master/instrumentation/runtime) to collect runtime metrics for GC, heap use, and goroutines. 
+  * Go [has instrumentation](https://github.com/open-telemetry/opentelemetry-go-contrib/tree/master/instrumentation/runtime) to collect runtime metrics for GC, heap use, and goroutines.
   * This package does not export metrics with labels, instead exporting individual metrics.
   * [Overview of collected metrics](https://docs.google.com/spreadsheets/d/1r50cC9ass0A8SZIg2ZpLdvZf6HmQJsUSXFOu-rl4yaY/edit#gid=0).
 - **Python**
@@ -36,18 +37,21 @@ There are already a few implementations of system and/or runtime metric collecti
 - **TODO: Opencensus**
 
 ## Semantic Conventions
+
 The following semantic conventions aim to keep naming consistent across different metrics. Not all possible metrics are covered by these conventions, but they provide guidelines for most of the cases in this proposal:
+
 - **usage** - an instrument that measures an amount used out of a known total amount should be called `entity.usage`. For example, `system.filesystem.usage` for the amount of disk spaced used. A measure of the amount of an unlimited resource consumed is differentiated from **usage**. This may be time, data, etc. *(I'm open to adjusting this to unit names or something else).*
 - **utilization** - an instrument that measures percent usage should be called `entity.utilization`. For example, `system.memory.utilization` for the percentage of memory in use. *(I'm open to a shorter name, but wanted to distinguish between usage as an amount and a percentage).*
 - **time** - an instrument that measures passage of time should be called `entity.time`. For example, `system.cpu.time` with varying values of label `state` for idle, user, etc.
 - **io** - an instrument that measures bidirectional data flow should be called `entity.io` and have labels for direction. For example, `system.net.io`.
 - Other metrics that do not fit the above descriptions may be named more freely. For example, `system.swap.page_faults` and `system.net.packets`. Units do not need to be specified in the names since they are included during instrument creation, but can be added if there is ambiguity.
 
-
 ## Internal details
+
 The following standard metric names should be used in libraries instrumenting system/runtime metrics (here is a [spreadsheet](https://docs.google.com/spreadsheets/d/1r50cC9ass0A8SZIg2ZpLdvZf6HmQJsUSXFOu-rl4yaY/edit#gid=973941697) of the tables below).
 
 ### Standard System Metrics - `system.`
+
 ---
 
 #### `system.cpu.`
@@ -121,16 +125,18 @@ The following standard metric names should be used in libraries instrumenting sy
 |                           |     |                 |state    |[e.g. for tcp](https://en.wikipedia.org/wiki/Transmission_Control_Protocol#Protocol_operation)|
 
 #### OS Specific System Metrics - `system.{os}.`
+
 System level metrics specific to a certain operating system should be prefixed with `system.{os}.` and follow the hierarchies listed above for different entities like CPU, memory, and network. For example, metrics pertaining to Linux inodes would appear under `system.linux.filesystem.inodes.*`, reusing the `filesystem` name proposed above.
 
 ### Standard Runtime Metrics - `runtime.`
+
 ---
 
 Runtime environments vary widely in their terminology, implementation, and relative values for a given metric. For example, Go and Python are both garbage collected languages, but comparing heap usage between the two runtimes directly is not meaningful. For this reason, this OTEP does not propose any standard top-level runtime metrics. See [OTEP #108](https://github.com/open-telemetry/oteps/pull/108/files) for additional discussion.
 
 #### Runtime Specific Metrics - `runtime.{environment}.`
-Runtime level metrics specific to a certain runtime environment should be prefixed with `runtime.{environment}.` and follow the semantic conventions outlined in [Semantic Conventions](#semantic-conventions).
 
+Runtime level metrics specific to a certain runtime environment should be prefixed with `runtime.{environment}.` and follow the semantic conventions outlined in [Semantic Conventions](#semantic-conventions).
 
 ## Open questions
 


### PR DESCRIPTION
See https://github.com/open-telemetry/opentelemetry-specification/issues/651. This OTEP proposes some standard system metric names as well as semantic conventions for naming system/runtime metrics. This mostly follows the work done in #108 and the Collector. I left a few TODOs and open questions, the biggest things being standard runtime metrics and process metrics.