### PR TITLE
Add metric semantic conventions for timed operations

### DIFF
--- a/text/metrics/0129-semantic-conventions-for-timed-operations.md
+++ b/text/metrics/0129-semantic-conventions-for-timed-operations.md
@@ -15,7 +15,7 @@ the duration of each instance of the timed operation is recorded.
 ### Naming
 
 The semantic conventions should specify the naming of this metric instrument, following
-the [Metric Instrument Naming Guidelines](./108-naming-guidelines.md#guidelines).
+the [Metric Instrument Naming Guidelines](./0108-naming-guidelines.md#guidelines).
 
 The goal of the semantic conventions regarding the naming of this metric instrument will
 be that similar operations are rolled up together.

--- a/text/metrics/129-semantic-conventions-for-timed-operations.md
+++ b/text/metrics/129-semantic-conventions-for-timed-operations.md
@@ -1,0 +1,31 @@
+# Semantic Conventions for Timed Operations
+
+## Motivation
+
+Timed operations are generally fully described by Spans. Because these Spans may be
+sampled, aggregating information about them downstream is subject to inaccuracies.
+Computing count, duration, and error rate from _all_ operations, regardless of whether
+the result in a sampled Span, results in more accurate aggregates.
+
+## Explanation
+
+Summarization of timed operations may be done with a single `ValueRecorder`, onto which
+the duration of each instance of the timed operation is recorded.
+
+### Naming
+
+The semantic conventions should specify the naming of this metric instrument, following
+the [Metric Instrument Naming Guidelines](./108-naming-guidelines.md#guidelines).
+
+The goal of the semantic conventions regarding the naming of this metric instrument will
+be that similar operations are rolled up together.
+
+### Labels
+
+The attributes described in the existing tracing semantic conventions provide guidance
+for the labels to be added to this metric instrument. Some of these attributes will
+result in very high cardinality; the semantic conventions should describe which attributes
+should be included and which should be omitted or reformatted to reduce cardinality.
+
+In addition, the tracing attributes allow more value types than metric instrument labels,
+so semantic conventions must describe how to represent those values as labels.


### PR DESCRIPTION
This OTEP attempts to address https://github.com/open-telemetry/opentelemetry-specification/issues/654.

I'd like us to come to agreement that we ought to have semantic conventions describing timing metrics.  These semantic conventions will describe what instrument(s) are created, how they are named, and what labels are applied to them.  They will not describe how or where the instruments are created and incremented.