### PR TITLE
Restrict LogRecord Body to string in Logging SDKs

### DIFF
--- a/text/logs/0150-logging-library-sdk.md
+++ b/text/logs/0150-logging-library-sdk.md
@@ -91,7 +91,9 @@ Methods:
 
 See LogRecord
 [data model](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/logs/data-model.md)
-for the list of fields.
+for the list of fields. SDKs should restrict the
+[Body](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/logs/data-model.md#field-body)
+field to a string value.
 
 Open Question: should LoggerName field be added to the data model to allow
 logging libraries to supply it? We have an


### PR DESCRIPTION
Discussions in the Logs SIG have reached consensus that the Body
of a LogRecord should be restricted in Logging SDKs.

The logs data model technically allows the Body to be arbitrarily
structured, but this is only for the sake of preserving the
semantics of legacy log formats.

It is intended that the Attributes field should be used for all
structured logs and the Body should contain only a string message.

Resolves [(specification) #2068](https://github.com/open-telemetry/opentelemetry-specification/issues/2068)