### PR TITLE
Fix markdown-lint by pinning version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -38,7 +38,7 @@ enforce-markdown-link-check:
 
 .PHONY: install-markdown-lint
 install-markdown-lint:
-	npm install -g markdownlint-cli
+	npm install -g markdownlint-cli@0.30.0
 
 .PHONY: markdown-lint
 markdown-lint:


### PR DESCRIPTION
The markdown-lint is updated and the rules have changed and existing
OTEPs are now failing the linting.

This pins the version to avoid failures.

A future PR can be submitted to update the markdown-lint version and fix
all OTEPs according to new rules.