### PR TITLE
profiles: fix index in example

### DIFF
--- a/text/profiles/0239-profiles-data-model.md
+++ b/text/profiles/0239-profiles-data-model.md
@@ -1349,7 +1349,7 @@ sample:
     locations_length: 3
     value:
       - 100
-  - locations_start_index: 2
+  - locations_start_index: 4
     locations_length: 2
     value:
       - 200

--- a/text/profiles/0239-profiles-data-model.md
+++ b/text/profiles/0239-profiles-data-model.md
@@ -1361,8 +1361,8 @@ location_indices:
   - 0 # foo
   - 1 # bar
   - 2 # baz
-  - 4 # abc
-  - 5 # def
+  - 3 # abc
+  - 4 # def
 location:
   - line:
       - function_index: 0 # foo

--- a/text/profiles/0239-profiles-data-model.md
+++ b/text/profiles/0239-profiles-data-model.md
@@ -1349,7 +1349,7 @@ sample:
     locations_length: 3
     value:
       - 100
-  - locations_start_index: 4
+  - locations_start_index: 3
     locations_length: 2
     value:
       - 200


### PR DESCRIPTION
For `abc;def` the `locations_start_index` should be `4` as `2` points to `baz`.

Follow up of https://github.com/open-telemetry/oteps/pull/239#discussion_r1496062414