### PR TITLE
Migrate CircleCI to GitHub Actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,36 @@
+name: Build
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+
+jobs:
+  misspell:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Misspell Install
+        run: make install-misspell
+
+      - name: Misspell check
+        run: make misspell
+
+  markdownlint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Tools
+        run: |
+          make install-markdown-lint
+          make install-markdown-link-check
+
+      - name: Run Tools
+        run: |
+          make markdown-lint
+          # Disabled for the moment because too many requests to github.com
+          # and we receive errors for valid links.
+          # make enforce-markdown-link-check


### PR DESCRIPTION
Related to https://github.com/open-telemetry/community/issues/2206

After merging, we can update the require checks in this repo and then I'll send a follow-up to remove the existing CircleCI checks