### PR TITLE
Add a header warning to all OTEPs.

### DIFF
--- a/.markdownlint.yaml
+++ b/.markdownlint.yaml
@@ -6,5 +6,6 @@
   "ul-style": false,  # MD004
   "line-length": false,  # MD013
   "no-inline-html": false,  # MD033
-  "fenced-code-language": false  # MD040
+  "fenced-code-language": false,  # MD040
+  "first-line-h1": false # MD041
 }

--- a/text/0001-telemetry-without-manual-instrumentation.md
+++ b/text/0001-telemetry-without-manual-instrumentation.md
@@ -1,3 +1,8 @@
+> [!WARNING]
+> OTEPs have been moved to the [Specification](https://github.com/open-telemetry/opentelemetry-specification/tree/main/oteps/)
+> repository. This repository has been preserved for reference purposes.
+> Please otherwise refer to the Specification.
+
 # (Open) Telemetry Without Manual Instrumentation
 
 _Cross-language requirements for automated approaches to extracting portable telemetry data with zero source code modification._

--- a/text/0005-global-init.md
+++ b/text/0005-global-init.md
@@ -1,3 +1,8 @@
+> [!WARNING]
+> OTEPs have been moved to the [Specification](https://github.com/open-telemetry/opentelemetry-specification/tree/main/oteps/)
+> repository. This repository has been preserved for reference purposes.
+> Please otherwise refer to the Specification.
+
 # Global SDK initialization
 
 **Status**: proposed

--- a/text/0007-no-out-of-band-reporting.md
+++ b/text/0007-no-out-of-band-reporting.md
@@ -1,3 +1,8 @@
+> [!WARNING]
+> OTEPs have been moved to the [Specification](https://github.com/open-telemetry/opentelemetry-specification/tree/main/oteps/)
+> repository. This repository has been preserved for reference purposes.
+> Please otherwise refer to the Specification.
+
 # Remove support to report out-of-band telemetry from the API
 
 ## TL;DR

--- a/text/0016-named-tracers.md
+++ b/text/0016-named-tracers.md
@@ -1,3 +1,8 @@
+> [!WARNING]
+> OTEPs have been moved to the [Specification](https://github.com/open-telemetry/opentelemetry-specification/tree/main/oteps/)
+> repository. This repository has been preserved for reference purposes.
+> Please otherwise refer to the Specification.
+
 # Named Tracers and Meters
 
 _Associate Tracers and Meters with the name and version of the instrumentation library which reports telemetry data by parameterizing the API which the library uses to acquire the Tracer or Meter._

--- a/text/0035-opentelemetry-protocol.md
+++ b/text/0035-opentelemetry-protocol.md
@@ -1,3 +1,8 @@
+> [!WARNING]
+> OTEPs have been moved to the [Specification](https://github.com/open-telemetry/opentelemetry-specification/tree/main/oteps/)
+> repository. This repository has been preserved for reference purposes.
+> Please otherwise refer to the Specification.
+
 # OpenTelemetry Protocol Specification
 
 **Author**: Tigran Najaryan, Omnition Inc.

--- a/text/0038-version-semantic-attribute.md
+++ b/text/0038-version-semantic-attribute.md
@@ -1,3 +1,8 @@
+> [!WARNING]
+> OTEPs have been moved to the [Specification](https://github.com/open-telemetry/opentelemetry-specification/tree/main/oteps/)
+> repository. This repository has been preserved for reference purposes.
+> Please otherwise refer to the Specification.
+
 # Version Semantic Attribute
 
 Add a standard `version` semantic attribute.

--- a/text/0066-separate-context-propagation.md
+++ b/text/0066-separate-context-propagation.md
@@ -1,3 +1,8 @@
+> [!WARNING]
+> OTEPs have been moved to the [Specification](https://github.com/open-telemetry/opentelemetry-specification/tree/main/oteps/)
+> repository. This repository has been preserved for reference purposes.
+> Please otherwise refer to the Specification.
+
 # Context Propagation: A Layered Approach
 
 * [Motivation](#Motivation)

--- a/text/0083-component.md
+++ b/text/0083-component.md
@@ -1,3 +1,8 @@
+> [!WARNING]
+> OTEPs have been moved to the [Specification](https://github.com/open-telemetry/opentelemetry-specification/tree/main/oteps/)
+> repository. This repository has been preserved for reference purposes.
+> Please otherwise refer to the Specification.
+
 # InstrumentationLibrary
 
 Introducing the notion of `InstrumentationLibrary` as a first class concept in

--- a/text/0099-otlp-http.md
+++ b/text/0099-otlp-http.md
@@ -1,3 +1,8 @@
+> [!WARNING]
+> OTEPs have been moved to the [Specification](https://github.com/open-telemetry/opentelemetry-specification/tree/main/oteps/)
+> repository. This repository has been preserved for reference purposes.
+> Please otherwise refer to the Specification.
+
 # OTLP/HTTP: HTTP Transport Extension for OTLP
 
 This is a proposal to add HTTP Transport extension for

--- a/text/0110-z-pages.md
+++ b/text/0110-z-pages.md
@@ -1,3 +1,8 @@
+> [!WARNING]
+> OTEPs have been moved to the [Specification](https://github.com/open-telemetry/opentelemetry-specification/tree/main/oteps/)
+> repository. This repository has been preserved for reference purposes.
+> Please otherwise refer to the Specification.
+
 # zPages: general direction (#110)
 
 Make zPages a standard OpenTelemetry component.

--- a/text/0111-auto-resource-detection.md
+++ b/text/0111-auto-resource-detection.md
@@ -1,3 +1,8 @@
+> [!WARNING]
+> OTEPs have been moved to the [Specification](https://github.com/open-telemetry/opentelemetry-specification/tree/main/oteps/)
+> repository. This repository has been preserved for reference purposes.
+> Please otherwise refer to the Specification.
+
 # Automatic Resource Detection
 
 Introduce a mechanism to support auto-detection of resources.

--- a/text/0119-standard-system-metrics.md
+++ b/text/0119-standard-system-metrics.md
@@ -1,3 +1,8 @@
+> [!WARNING]
+> OTEPs have been moved to the [Specification](https://github.com/open-telemetry/opentelemetry-specification/tree/main/oteps/)
+> repository. This repository has been preserved for reference purposes.
+> Please otherwise refer to the Specification.
+
 # Standard names for system/runtime metric instruments
 
 This OTEP proposes a set of standard names, labels, and semantic conventions for common system/runtime metric instruments in OpenTelemetry. The instrument names proposed here are common across the supported operating systems and runtime environments. Also included are general semantic conventions for system/runtime metrics including those not specific to a particular OS or runtime.

--- a/text/0122-otlp-http-json.md
+++ b/text/0122-otlp-http-json.md
@@ -1,3 +1,8 @@
+> [!WARNING]
+> OTEPs have been moved to the [Specification](https://github.com/open-telemetry/opentelemetry-specification/tree/main/oteps/)
+> repository. This repository has been preserved for reference purposes.
+> Please otherwise refer to the Specification.
+
 # OTLP: JSON Encoding for OTLP/HTTP
 
 This is a proposal to add HTTP Transport extension supporting json serialization for

--- a/text/0143-versioning-and-stability.md
+++ b/text/0143-versioning-and-stability.md
@@ -1,3 +1,8 @@
+> [!WARNING]
+> OTEPs have been moved to the [Specification](https://github.com/open-telemetry/opentelemetry-specification/tree/main/oteps/)
+> repository. This repository has been preserved for reference purposes.
+> Please otherwise refer to the Specification.
+
 # Versioning and stability for OpenTelemetry clients
 
 OpenTelemetry is a large project with strict compatibility requirements. This proposal defines the stability guarantees offered by the OpenTelemetry clients, along with a versioning and lifecycle proposal which defines how we meet those requirements.

--- a/text/0147-upgrade-procedures.md
+++ b/text/0147-upgrade-procedures.md
@@ -1,3 +1,8 @@
+> [!WARNING]
+> OTEPs have been moved to the [Specification](https://github.com/open-telemetry/opentelemetry-specification/tree/main/oteps/)
+> repository. This repository has been preserved for reference purposes.
+> Please otherwise refer to the Specification.
+
 # The OpenTelemetry approach to upgrading
 
 Managing widely distributed software at scale requires careful design related to backwards compatibility, versioning, and upgrading. The OpenTelemetry approach is described below. If you are planning on using OpenTelemetry, it can be helpful to understand how we approach this problem.

--- a/text/0149-exponential-histogram.md
+++ b/text/0149-exponential-histogram.md
@@ -1,3 +1,8 @@
+> [!WARNING]
+> OTEPs have been moved to the [Specification](https://github.com/open-telemetry/opentelemetry-specification/tree/main/oteps/)
+> repository. This repository has been preserved for reference purposes.
+> Please otherwise refer to the Specification.
+
 # Add exponential bucketing to histogram protobuf
 
 Add exponential bucketing to histogram protobuf

--- a/text/0152-telemetry-schemas.md
+++ b/text/0152-telemetry-schemas.md
@@ -1,3 +1,8 @@
+> [!WARNING]
+> OTEPs have been moved to the [Specification](https://github.com/open-telemetry/opentelemetry-specification/tree/main/oteps/)
+> repository. This repository has been preserved for reference purposes.
+> Please otherwise refer to the Specification.
+
 # Telemetry Schemas
 
 * [Motivation](#motivation)

--- a/text/0155-external-modules.md
+++ b/text/0155-external-modules.md
@@ -1,3 +1,8 @@
+> [!WARNING]
+> OTEPs have been moved to the [Specification](https://github.com/open-telemetry/opentelemetry-specification/tree/main/oteps/)
+> repository. This repository has been preserved for reference purposes.
+> Please otherwise refer to the Specification.
+
 # Ecosystem Management
 
 Proposal how to leverage wider community contributing instrumentations and other packages.

--- a/text/0156-columnar-encoding.md
+++ b/text/0156-columnar-encoding.md
@@ -1,3 +1,8 @@
+> [!WARNING]
+> OTEPs have been moved to the [Specification](https://github.com/open-telemetry/opentelemetry-specification/tree/main/oteps/)
+> repository. This repository has been preserved for reference purposes.
+> Please otherwise refer to the Specification.
+
 # OTel Arrow Protocol Specification
 
 **Author**: Laurent Querel, F5 Inc.

--- a/text/0178-mapping-to-otlp-anyvalue.md
+++ b/text/0178-mapping-to-otlp-anyvalue.md
@@ -1,3 +1,8 @@
+> [!WARNING]
+> OTEPs have been moved to the [Specification](https://github.com/open-telemetry/opentelemetry-specification/tree/main/oteps/)
+> repository. This repository has been preserved for reference purposes.
+> Please otherwise refer to the Specification.
+
 # Mapping Arbitrary Data to OTLP AnyValue
 
 This document defines how to map (convert) arbitrary data (e.g. in-memory

--- a/text/0182-otlp-remote-parent.md
+++ b/text/0182-otlp-remote-parent.md
@@ -1,3 +1,8 @@
+> [!WARNING]
+> OTEPs have been moved to the [Specification](https://github.com/open-telemetry/opentelemetry-specification/tree/main/oteps/)
+> repository. This repository has been preserved for reference purposes.
+> Please otherwise refer to the Specification.
+
 # Export SpanContext.IsRemote in OTLP
 
 Update OTLP to indicate whether a span's parent is remote.

--- a/text/0199-support-elastic-common-schema-in-opentelemetry.md
+++ b/text/0199-support-elastic-common-schema-in-opentelemetry.md
@@ -1,3 +1,8 @@
+> [!WARNING]
+> OTEPs have been moved to the [Specification](https://github.com/open-telemetry/opentelemetry-specification/tree/main/oteps/)
+> repository. This repository has been preserved for reference purposes.
+> Please otherwise refer to the Specification.
+
 # Merge Elastic Common Schema with OpenTelemetry Semantic Conventions
 
 ## Introduction

--- a/text/0201-scope-attributes.md
+++ b/text/0201-scope-attributes.md
@@ -1,3 +1,8 @@
+> [!WARNING]
+> OTEPs have been moved to the [Specification](https://github.com/open-telemetry/opentelemetry-specification/tree/main/oteps/)
+> repository. This repository has been preserved for reference purposes.
+> Please otherwise refer to the Specification.
+
 # Introduce Scope Attributes
 
 This OTEP adds attributes to the Scope of a telemetry emitter (e.g. Tracer, Meter, LogEmitter).

--- a/text/0202-events-and-logs-api.md
+++ b/text/0202-events-and-logs-api.md
@@ -1,3 +1,8 @@
+> [!WARNING]
+> OTEPs have been moved to the [Specification](https://github.com/open-telemetry/opentelemetry-specification/tree/main/oteps/)
+> repository. This repository has been preserved for reference purposes.
+> Please otherwise refer to the Specification.
+
 # Introducing Events and Logs API
 
 We introduce an Events and Logs API that is based on the OpenTelemetry Log signal, backed by LogRecord data model and LogEmitter SDK.

--- a/text/0225-configuration.md
+++ b/text/0225-configuration.md
@@ -1,3 +1,8 @@
+> [!WARNING]
+> OTEPs have been moved to the [Specification](https://github.com/open-telemetry/opentelemetry-specification/tree/main/oteps/)
+> repository. This repository has been preserved for reference purposes.
+> Please otherwise refer to the Specification.
+
 # OpenTelemetry Configuration
 
 A new configuration interface is proposed here in the form of a configuration model, which can be expressed as a file, and validated through a published schema.

--- a/text/0227-separate-semantic-conventions.md
+++ b/text/0227-separate-semantic-conventions.md
@@ -1,3 +1,8 @@
+> [!WARNING]
+> OTEPs have been moved to the [Specification](https://github.com/open-telemetry/opentelemetry-specification/tree/main/oteps/)
+> repository. This repository has been preserved for reference purposes.
+> Please otherwise refer to the Specification.
+
 # Separate Semantic Conventions
 
 Move Semantic Conventions outside of the main Specifications and version them

--- a/text/0232-maturity-of-otel.md
+++ b/text/0232-maturity-of-otel.md
@@ -1,3 +1,8 @@
+> [!WARNING]
+> OTEPs have been moved to the [Specification](https://github.com/open-telemetry/opentelemetry-specification/tree/main/oteps/)
+> repository. This repository has been preserved for reference purposes.
+> Please otherwise refer to the Specification.
+
 # Definition of maturity levels to be uniformly used by OpenTelemetry SIGs
 
 On 08 Mar 2023, the OpenTelemetry GC and TC held an OpenTelemetry Leadership summit, discussing various topics. One of the themes we discussed was establishing standard rules for describing the maturity of the OpenTelemetry project. This OTEP summarizes what was discussed there and is intended to have the wider community provide feedback.

--- a/text/0243-app-telemetry-schema-vision-roadmap.md
+++ b/text/0243-app-telemetry-schema-vision-roadmap.md
@@ -1,3 +1,8 @@
+> [!WARNING]
+> OTEPs have been moved to the [Specification](https://github.com/open-telemetry/opentelemetry-specification/tree/main/oteps/)
+> repository. This repository has been preserved for reference purposes.
+> Please otherwise refer to the Specification.
+
 # Introducing Application Telemetry Schema in OpenTelemetry - Vision and Roadmap
 
 ----

--- a/text/0258-env-context-baggage-carriers.md
+++ b/text/0258-env-context-baggage-carriers.md
@@ -1,3 +1,8 @@
+> [!WARNING]
+> OTEPs have been moved to the [Specification](https://github.com/open-telemetry/opentelemetry-specification/tree/main/oteps/)
+> repository. This repository has been preserved for reference purposes.
+> Please otherwise refer to the Specification.
+
 # Environment Variable Specification for Context and Baggage Propagation
 
 This is a proposal to add Environment Variables to the OpenTelemetry

--- a/text/0265-event-vision.md
+++ b/text/0265-event-vision.md
@@ -1,3 +1,8 @@
+> [!WARNING]
+> OTEPs have been moved to the [Specification](https://github.com/open-telemetry/opentelemetry-specification/tree/main/oteps/)
+> repository. This repository has been preserved for reference purposes.
+> Please otherwise refer to the Specification.
+
 # Event Basics
 
 ## Motivation

--- a/text/0266-move-oteps-to-spec.md
+++ b/text/0266-move-oteps-to-spec.md
@@ -1,3 +1,8 @@
+> [!WARNING]
+> OTEPs have been moved to the [Specification](https://github.com/open-telemetry/opentelemetry-specification/tree/main/oteps/)
+> repository. This repository has been preserved for reference purposes.
+> Please otherwise refer to the Specification.
+
 # Move OTEPS to the Specification repository
 
 Let's move OTEP documentation and PRs back into the github.com/open-telemetry/opentelemetry-specification repository.

--- a/text/entities/0256-entities-data-model.md
+++ b/text/entities/0256-entities-data-model.md
@@ -1,3 +1,8 @@
+> [!WARNING]
+> OTEPs have been moved to the [Specification](https://github.com/open-telemetry/opentelemetry-specification/tree/main/oteps/)
+> repository. This repository has been preserved for reference purposes.
+> Please otherwise refer to the Specification.
+
 # Entities Data Model, Part 1
 
 This is a proposal of a data model to represent entities. The purpose of the data model

--- a/text/entities/0264-resource-and-entities.md
+++ b/text/entities/0264-resource-and-entities.md
@@ -1,3 +1,8 @@
+> [!WARNING]
+> OTEPs have been moved to the [Specification](https://github.com/open-telemetry/opentelemetry-specification/tree/main/oteps/)
+> repository. This repository has been preserved for reference purposes.
+> Please otherwise refer to the Specification.
+
 # Resource and Entities - Data Model Part 2
 
 This is a proposal to address Resource and Entity data model interactions,

--- a/text/experimental/0121-config-service.md
+++ b/text/experimental/0121-config-service.md
@@ -1,3 +1,8 @@
+> [!WARNING]
+> OTEPs have been moved to the [Specification](https://github.com/open-telemetry/opentelemetry-specification/tree/main/oteps/)
+> repository. This repository has been preserved for reference purposes.
+> Please otherwise refer to the Specification.
+
 # A Dynamic Configuration Service for the SDK
 
 This proposal is a request to develop a prototype to configure metric collection periods. Per-metric and tracing configuration is also intended to be added, with details left for a later iteration.

--- a/text/logs/0091-logs-vocabulary.md
+++ b/text/logs/0091-logs-vocabulary.md
@@ -1,3 +1,8 @@
+> [!WARNING]
+> OTEPs have been moved to the [Specification](https://github.com/open-telemetry/opentelemetry-specification/tree/main/oteps/)
+> repository. This repository has been preserved for reference purposes.
+> Please otherwise refer to the Specification.
+
 # Logs: Vocabulary
 
 This documents defines the vocabulary for logs to be used across OpenTelemetry project.

--- a/text/logs/0092-logs-vision.md
+++ b/text/logs/0092-logs-vision.md
@@ -1,3 +1,8 @@
+> [!WARNING]
+> OTEPs have been moved to the [Specification](https://github.com/open-telemetry/opentelemetry-specification/tree/main/oteps/)
+> repository. This repository has been preserved for reference purposes.
+> Please otherwise refer to the Specification.
+
 # OpenTelemetry Logs Vision
 
 The following are high-level items that define our long-term vision for

--- a/text/logs/0097-log-data-model.md
+++ b/text/logs/0097-log-data-model.md
@@ -1,3 +1,8 @@
+> [!WARNING]
+> OTEPs have been moved to the [Specification](https://github.com/open-telemetry/opentelemetry-specification/tree/main/oteps/)
+> repository. This repository has been preserved for reference purposes.
+> Please otherwise refer to the Specification.
+
 # Log Data Model
 
 Introduce Data Model for Log Records as it is understood by OpenTelemetry.

--- a/text/logs/0130-logs-1.0ga-definition.md
+++ b/text/logs/0130-logs-1.0ga-definition.md
@@ -1,3 +1,8 @@
+> [!WARNING]
+> OTEPs have been moved to the [Specification](https://github.com/open-telemetry/opentelemetry-specification/tree/main/oteps/)
+> repository. This repository has been preserved for reference purposes.
+> Please otherwise refer to the Specification.
+
 # Logs GA Scope
 
 This document defines what's in scope for OpenTelemetry Logs General

--- a/text/logs/0150-logging-library-sdk.md
+++ b/text/logs/0150-logging-library-sdk.md
@@ -1,3 +1,8 @@
+> [!WARNING]
+> OTEPs have been moved to the [Specification](https://github.com/open-telemetry/opentelemetry-specification/tree/main/oteps/)
+> repository. This repository has been preserved for reference purposes.
+> Please otherwise refer to the Specification.
+
 # Logging Library SDK Prototype Specification
 
 Initial draft specification to create prototypes of OpenTelemetry Logging

--- a/text/metrics/0003-measure-metric-type.md
+++ b/text/metrics/0003-measure-metric-type.md
@@ -1,3 +1,8 @@
+> [!WARNING]
+> OTEPs have been moved to the [Specification](https://github.com/open-telemetry/opentelemetry-specification/tree/main/oteps/)
+> repository. This repository has been preserved for reference purposes.
+> Please otherwise refer to the Specification.
+
 # Consolidate pre-aggregated and raw metrics APIs
 
 ## Foreword

--- a/text/metrics/0008-metric-observer.md
+++ b/text/metrics/0008-metric-observer.md
@@ -1,3 +1,8 @@
+> [!WARNING]
+> OTEPs have been moved to the [Specification](https://github.com/open-telemetry/opentelemetry-specification/tree/main/oteps/)
+> repository. This repository has been preserved for reference purposes.
+> Please otherwise refer to the Specification.
+
 # Metrics observer specification
 
 **Status:** Superceded entirely by [0072-metric-observer](0072-metric-observer.md)

--- a/text/metrics/0009-metric-handles.md
+++ b/text/metrics/0009-metric-handles.md
@@ -1,3 +1,8 @@
+> [!WARNING]
+> OTEPs have been moved to the [Specification](https://github.com/open-telemetry/opentelemetry-specification/tree/main/oteps/)
+> repository. This repository has been preserved for reference purposes.
+> Please otherwise refer to the Specification.
+
 # Metric Handle API specification
 
 Specify the behavior of the Metrics API "Handle" type, for efficient repeated-use of metric instruments.

--- a/text/metrics/0010-cumulative-to-counter.md
+++ b/text/metrics/0010-cumulative-to-counter.md
@@ -1,3 +1,8 @@
+> [!WARNING]
+> OTEPs have been moved to the [Specification](https://github.com/open-telemetry/opentelemetry-specification/tree/main/oteps/)
+> repository. This repository has been preserved for reference purposes.
+> Please otherwise refer to the Specification.
+
 # Rename "Cumulative" to "Counter" in the metrics API
 
 Prefer the name "Counter" as opposed to "Cumulative".

--- a/text/metrics/0049-metric-label-set.md
+++ b/text/metrics/0049-metric-label-set.md
@@ -1,3 +1,8 @@
+> [!WARNING]
+> OTEPs have been moved to the [Specification](https://github.com/open-telemetry/opentelemetry-specification/tree/main/oteps/)
+> repository. This repository has been preserved for reference purposes.
+> Please otherwise refer to the Specification.
+
 # Metric `LabelSet` specification
 
 Introduce a first-class `LabelSet` API type as a handle on a pre-defined set of labels for the Metrics API.

--- a/text/metrics/0070-metric-bound-instrument.md
+++ b/text/metrics/0070-metric-bound-instrument.md
@@ -1,3 +1,8 @@
+> [!WARNING]
+> OTEPs have been moved to the [Specification](https://github.com/open-telemetry/opentelemetry-specification/tree/main/oteps/)
+> repository. This repository has been preserved for reference purposes.
+> Please otherwise refer to the Specification.
+
 # Rename metric instrument Handles to "Bound Instruments"
 
 The OpenTelemetry metrics API specification refers to a concept known

--- a/text/metrics/0072-metric-observer.md
+++ b/text/metrics/0072-metric-observer.md
@@ -1,3 +1,8 @@
+> [!WARNING]
+> OTEPs have been moved to the [Specification](https://github.com/open-telemetry/opentelemetry-specification/tree/main/oteps/)
+> repository. This repository has been preserved for reference purposes.
+> Please otherwise refer to the Specification.
+
 # Metric observer specification (refinement)
 
 The metric observer gauge was described in [OTEP

--- a/text/metrics/0080-remove-metric-gauge.md
+++ b/text/metrics/0080-remove-metric-gauge.md
@@ -1,3 +1,8 @@
+> [!WARNING]
+> OTEPs have been moved to the [Specification](https://github.com/open-telemetry/opentelemetry-specification/tree/main/oteps/)
+> repository. This repository has been preserved for reference purposes.
+> Please otherwise refer to the Specification.
+
 # Remove the Metric API Gauge instrument
 
 The [Observer instrument](./0072-metric-observer.md) is semantically

--- a/text/metrics/0088-metric-instrument-optional-refinements.md
+++ b/text/metrics/0088-metric-instrument-optional-refinements.md
@@ -1,3 +1,8 @@
+> [!WARNING]
+> OTEPs have been moved to the [Specification](https://github.com/open-telemetry/opentelemetry-specification/tree/main/oteps/)
+> repository. This repository has been preserved for reference purposes.
+> Please otherwise refer to the Specification.
+
 # Metric Instruments
 
 Removes the optional semantic declarations `Monotonic` and `Absolute`

--- a/text/metrics/0090-remove-labelset-from-metrics-api.md
+++ b/text/metrics/0090-remove-labelset-from-metrics-api.md
@@ -1,3 +1,8 @@
+> [!WARNING]
+> OTEPs have been moved to the [Specification](https://github.com/open-telemetry/opentelemetry-specification/tree/main/oteps/)
+> repository. This repository has been preserved for reference purposes.
+> Please otherwise refer to the Specification.
+
 # Remove the LabelSet object from the metrics API
 
 The proposal is to remove the current [`LabelSet`](./0049-metric-label-set.md)

--- a/text/metrics/0098-metric-instruments-explained.md
+++ b/text/metrics/0098-metric-instruments-explained.md
@@ -1,3 +1,8 @@
+> [!WARNING]
+> OTEPs have been moved to the [Specification](https://github.com/open-telemetry/opentelemetry-specification/tree/main/oteps/)
+> repository. This repository has been preserved for reference purposes.
+> Please otherwise refer to the Specification.
+
 # Explain the metric instruments
 
 Propose and explain final names for the standard metric instruments theorized in [OTEP 88][otep-88] and address related confusion.

--- a/text/metrics/0108-naming-guidelines.md
+++ b/text/metrics/0108-naming-guidelines.md
@@ -1,3 +1,8 @@
+> [!WARNING]
+> OTEPs have been moved to the [Specification](https://github.com/open-telemetry/opentelemetry-specification/tree/main/oteps/)
+> repository. This repository has been preserved for reference purposes.
+> Please otherwise refer to the Specification.
+
 # Metric instrument naming guidelines
 
 ## Purpose

--- a/text/metrics/0113-exemplars.md
+++ b/text/metrics/0113-exemplars.md
@@ -1,3 +1,8 @@
+> [!WARNING]
+> OTEPs have been moved to the [Specification](https://github.com/open-telemetry/opentelemetry-specification/tree/main/oteps/)
+> repository. This repository has been preserved for reference purposes.
+> Please otherwise refer to the Specification.
+
 # Integrate Exemplars with Metrics
 
 This OTEP adds exemplar support to aggregations defined in the Metrics SDK.

--- a/text/metrics/0126-Configurable-Metric-Aggregations.md
+++ b/text/metrics/0126-Configurable-Metric-Aggregations.md
@@ -1,3 +1,8 @@
+> [!WARNING]
+> OTEPs have been moved to the [Specification](https://github.com/open-telemetry/opentelemetry-specification/tree/main/oteps/)
+> repository. This repository has been preserved for reference purposes.
+> Please otherwise refer to the Specification.
+
 # A Proposal For SDK Support for Configurable Batching and Aggregations (Basic Views)
 
 Add support to the default SDK for the ability to configure Metric Aggregations.

--- a/text/metrics/0131-otlp-export-behavior.md
+++ b/text/metrics/0131-otlp-export-behavior.md
@@ -1,3 +1,8 @@
+> [!WARNING]
+> OTEPs have been moved to the [Specification](https://github.com/open-telemetry/opentelemetry-specification/tree/main/oteps/)
+> repository. This repository has been preserved for reference purposes.
+> Please otherwise refer to the Specification.
+
 # OTLP Exporters Configurable Export Behavior
 
  Add support for configurable export behavior in OTLP exporters.

--- a/text/metrics/0146-metrics-prototype-scenarios.md
+++ b/text/metrics/0146-metrics-prototype-scenarios.md
@@ -1,3 +1,8 @@
+> [!WARNING]
+> OTEPs have been moved to the [Specification](https://github.com/open-telemetry/opentelemetry-specification/tree/main/oteps/)
+> repository. This repository has been preserved for reference purposes.
+> Please otherwise refer to the Specification.
+
 # Scenarios for Metrics API/SDK Prototyping
 
 With the stable release of the tracing specification, the OpenTelemetry

--- a/text/profiles/0212-profiling-vision.md
+++ b/text/profiles/0212-profiling-vision.md
@@ -1,3 +1,8 @@
+> [!WARNING]
+> OTEPs have been moved to the [Specification](https://github.com/open-telemetry/opentelemetry-specification/tree/main/oteps/)
+> repository. This repository has been preserved for reference purposes.
+> Please otherwise refer to the Specification.
+
 # Propose OpenTelemetry profiling vision
 
 The following are high-level items that define our long-term vision for

--- a/text/profiles/0239-profiles-data-model.md
+++ b/text/profiles/0239-profiles-data-model.md
@@ -1,3 +1,8 @@
+> [!WARNING]
+> OTEPs have been moved to the [Specification](https://github.com/open-telemetry/opentelemetry-specification/tree/main/oteps/)
+> repository. This repository has been preserved for reference purposes.
+> Please otherwise refer to the Specification.
+
 # Profiles Data Format
 
 Introduces Data Model for Profiles signal to OpenTelemetry.

--- a/text/trace/0002-remove-spandata.md
+++ b/text/trace/0002-remove-spandata.md
@@ -1,3 +1,8 @@
+> [!WARNING]
+> OTEPs have been moved to the [Specification](https://github.com/open-telemetry/opentelemetry-specification/tree/main/oteps/)
+> repository. This repository has been preserved for reference purposes.
+> Please otherwise refer to the Specification.
+
 # Remove SpanData
 
 Remove and replace SpanData by adding span start and end options.

--- a/text/trace/0006-sampling.md
+++ b/text/trace/0006-sampling.md
@@ -1,3 +1,8 @@
+> [!WARNING]
+> OTEPs have been moved to the [Specification](https://github.com/open-telemetry/opentelemetry-specification/tree/main/oteps/)
+> repository. This repository has been preserved for reference purposes.
+> Please otherwise refer to the Specification.
+
 # Sampling API
 
 ## TL;DR

--- a/text/trace/0059-otlp-trace-data-format.md
+++ b/text/trace/0059-otlp-trace-data-format.md
@@ -1,3 +1,8 @@
+> [!WARNING]
+> OTEPs have been moved to the [Specification](https://github.com/open-telemetry/opentelemetry-specification/tree/main/oteps/)
+> repository. This repository has been preserved for reference purposes.
+> Please otherwise refer to the Specification.
+
 # OTLP Trace Data Format
 
 **Author**: Tigran Najaryan, Splunk

--- a/text/trace/0136-error_flagging.md
+++ b/text/trace/0136-error_flagging.md
@@ -1,3 +1,8 @@
+> [!WARNING]
+> OTEPs have been moved to the [Specification](https://github.com/open-telemetry/opentelemetry-specification/tree/main/oteps/)
+> repository. This repository has been preserved for reference purposes.
+> Please otherwise refer to the Specification.
+
 # Error Flagging with Status Codes
 
 This proposal reduces the number of status codes to three, adds a new field to identify status codes set by application developers and operators, and adds a mapping of semantic conventions to status codes. This clarifies how error reporting should work in OpenTelemetry.

--- a/text/trace/0168-sampling-propagation.md
+++ b/text/trace/0168-sampling-propagation.md
@@ -1,3 +1,8 @@
+> [!WARNING]
+> OTEPs have been moved to the [Specification](https://github.com/open-telemetry/opentelemetry-specification/tree/main/oteps/)
+> repository. This repository has been preserved for reference purposes.
+> Please otherwise refer to the Specification.
+
 # Propagate parent sampling probability
 
 Use the W3C trace context to convey consistent parent sampling probability.

--- a/text/trace/0170-sampling-probability.md
+++ b/text/trace/0170-sampling-probability.md
@@ -1,3 +1,8 @@
+> [!WARNING]
+> OTEPs have been moved to the [Specification](https://github.com/open-telemetry/opentelemetry-specification/tree/main/oteps/)
+> repository. This repository has been preserved for reference purposes.
+> Please otherwise refer to the Specification.
+
 # Probability sampling of telemetry events
 
 <!-- toc -->

--- a/text/trace/0173-messaging-semantic-conventions.md
+++ b/text/trace/0173-messaging-semantic-conventions.md
@@ -1,3 +1,8 @@
+> [!WARNING]
+> OTEPs have been moved to the [Specification](https://github.com/open-telemetry/opentelemetry-specification/tree/main/oteps/)
+> repository. This repository has been preserved for reference purposes.
+> Please otherwise refer to the Specification.
+
 # Scenarios for Tracing semantic conventions for messaging
 
 This document aims to capture scenarios and a road map, both of which will

--- a/text/trace/0174-http-semantic-conventions.md
+++ b/text/trace/0174-http-semantic-conventions.md
@@ -1,3 +1,8 @@
+> [!WARNING]
+> OTEPs have been moved to the [Specification](https://github.com/open-telemetry/opentelemetry-specification/tree/main/oteps/)
+> repository. This repository has been preserved for reference purposes.
+> Please otherwise refer to the Specification.
+
 # Scenarios and Open Questions for Tracing semantic conventions for HTTP
 
 This document aims to capture scenarios/open questions and a road map, both of

--- a/text/trace/0205-messaging-semantic-conventions-context-propagation.md
+++ b/text/trace/0205-messaging-semantic-conventions-context-propagation.md
@@ -1,3 +1,8 @@
+> [!WARNING]
+> OTEPs have been moved to the [Specification](https://github.com/open-telemetry/opentelemetry-specification/tree/main/oteps/)
+> repository. This repository has been preserved for reference purposes.
+> Please otherwise refer to the Specification.
+
 # Context propagation requirements for messaging semantic conventions
 
 The [existing messaging semantic conventions for tracing](https://github.com/open-telemetry/opentelemetry-specification/blob/v1.11.0/specification/trace/semantic_conventions/messaging.md)

--- a/text/trace/0220-messaging-semantic-conventions-span-structure.md
+++ b/text/trace/0220-messaging-semantic-conventions-span-structure.md
@@ -1,3 +1,8 @@
+> [!WARNING]
+> OTEPs have been moved to the [Specification](https://github.com/open-telemetry/opentelemetry-specification/tree/main/oteps/)
+> repository. This repository has been preserved for reference purposes.
+> Please otherwise refer to the Specification.
+
 # Span structure for messaging scenarios
 
 This OTEP aims at defining consistent conventions about what spans to create

--- a/text/trace/0235-sampling-threshold-in-trace-state.md
+++ b/text/trace/0235-sampling-threshold-in-trace-state.md
@@ -1,3 +1,8 @@
+> [!WARNING]
+> OTEPs have been moved to the [Specification](https://github.com/open-telemetry/opentelemetry-specification/tree/main/oteps/)
+> repository. This repository has been preserved for reference purposes.
+> Please otherwise refer to the Specification.
+
 # Sampling Threshold Propagation in TraceState
 
 ## Motivation


### PR DESCRIPTION
Since **direct** references to individual OTEPs may exist beyond the OTEL organization, we want to warn users about their deprecation, hence copying the warning from the README (merged) to individual files.